### PR TITLE
Added notebook to compare n. features to p-values

### DIFF
--- a/baseball_utils.py
+++ b/baseball_utils.py
@@ -1,0 +1,42 @@
+import pandas as pd
+
+
+# Function to prepare called-pitches dataframe for modelling
+# Output: X, y
+# X is a dataframe of observations of the input variables
+# y is a series of observations of the response variable
+# Function may take the better part of a minute to run
+# This is almost entirely due to the line which creates the UPM column
+def prepare_df(df):
+    # Drop counts where number of balls is > 3
+    df = df[df['count'].apply(lambda x: x[0]!='4')]
+    
+    # Convert strike-given-called to int
+    df['strike_given_called'] = df['strike_given_called'].apply(int)
+    
+    # Make column to check when umpire's race matches pitcher's race
+    # (1 if match, 0 if mismatch)
+    df['upm'] = df.apply(lambda x: x.pitcher_race==x.umpire_race, axis=1).apply(int)
+    
+    # Drop the race-value columns
+    df = df.drop(labels=['pitcher_race', 'umpire_race'], axis=1)
+    
+    # Convert innings greater than the ninth to 9
+    df.inning = df.inning.apply(lambda x: min(x,9))
+    
+    # Turn counts and innings into dummy variables
+    df = pd.get_dummies(df, columns=['count', 'inning'], drop_first=True)
+    
+    # Rearrange and rename columns
+    new_cols = ['strike_given_called', 'upm', 'home_pitcher', 'run_diff',
+            'count_0-1', 'count_0-2', 'count_1-0', 'count_1-1', 'count_1-2', 'count_2-0', 'count_2-1', 'count_2-2',
+           'count_3-0', 'count_3-1', 'count_3-2',
+           'inning_2', 'inning_3', 'inning_4', 'inning_5', 'inning_6', 'inning_7', 'inning_8', 'inning_9']
+    df = df[new_cols]
+    df = df.rename(columns={'inning_9': 'inning_9+'})
+    
+    # Add intercept column
+    df['intercept'] = 1
+    
+    # Return X dataframe, y series
+    return df.drop(labels=['strike_given_called'], axis=1), df['strike_given_called'] 

--- a/nfeatures_vs_p_upm.ipynb
+++ b/nfeatures_vs_p_upm.ipynb
@@ -1,0 +1,446 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# Tools for recursive feature selection\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.feature_selection import RFE\n",
+    "\n",
+    "# Tools for fitting logistic regression and getting p-values\n",
+    "import statsmodels.api as sm\n",
+    "\n",
+    "# For plotting\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Our local, useful function for preparing the merged dataframe for modeling\n",
+    "from baseball_utils import prepare_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use recursive feature selection to rank the features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the dataframe\n",
+    "cp_df = pd.read_csv(\"cp_merged.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/robertair2019/Desktop/upm/baseball_utils.py:15: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "  df['strike_given_called'] = df['strike_given_called'].apply(int)\n",
+      "/Users/robertair2019/Desktop/upm/baseball_utils.py:19: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "  df['upm'] = df.apply(lambda x: x.pitcher_race==x.umpire_race, axis=1).apply(int)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 37.1 s, sys: 408 ms, total: 37.5 s\n",
+      "Wall time: 36.9 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time X, y = prepare_df(cp_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 44.6 s, sys: 3.29 s, total: 47.9 s\n",
+      "Wall time: 39.9 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time rfe = RFE(LogisticRegression(solver=\"liblinear\"),1).fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[23 18 21  6  1 10  7  2 19  8  3  4  9  5 22 20 12 14 11 13 15 17 16]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The ranking position of the ith feature\n",
+    "print(rfe.ranking_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['upm', 'home_pitcher', 'run_diff', 'count_0-1', 'count_0-2',\n",
+      "       'count_1-0', 'count_1-1', 'count_1-2', 'count_2-0', 'count_2-1',\n",
+      "       'count_2-2', 'count_3-0', 'count_3-1', 'count_3-2', 'inning_2',\n",
+      "       'inning_3', 'inning_4', 'inning_5', 'inning_6', 'inning_7', 'inning_8',\n",
+      "       'inning_9+', 'intercept'],\n",
+      "      dtype='object')\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The features themselves\n",
+    "print(X.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Here we have ranked the features in order of significance:\n",
+    "* Notice that UPM appears lowest in the order of significance.\n",
+    "* This does not necessarily indicate that there is no effect, but rather, that the effect is subtle. In order to illustrate the importance of the control variables, we eliminate the non-UPM features one by one from the model, in order of increasing significance, and compare the UPM coefficient and corresponding p-value to the number of model features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranked_features = [X.columns.tolist()[np.where(rfe.ranking_ == i)[0][0]] for i in range(1,len(X.columns)+1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranked_features.remove('intercept')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1. count_0-2\n",
+      "2. count_1-2\n",
+      "3. count_2-2\n",
+      "4. count_3-0\n",
+      "5. count_3-2\n",
+      "6. count_0-1\n",
+      "7. count_1-1\n",
+      "8. count_2-1\n",
+      "9. count_3-1\n",
+      "10. count_1-0\n",
+      "11. inning_6\n",
+      "12. inning_4\n",
+      "13. inning_7\n",
+      "14. inning_5\n",
+      "15. inning_8\n",
+      "16. inning_9+\n",
+      "17. home_pitcher\n",
+      "18. count_2-0\n",
+      "19. inning_3\n",
+      "20. run_diff\n",
+      "21. inning_2\n",
+      "22. upm\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, f in enumerate(ranked_features):\n",
+    "    print(f\"{i+1}. {f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## We eliminate the features one-by-one and calculate UPM coefficients and p-values for the corresponding models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the ranked features\n",
+    "rf = ranked_features[:-1]\n",
+    "\n",
+    "# Initialize the p-values\n",
+    "p = []\n",
+    "\n",
+    "# Initialize the coefficients\n",
+    "beta = []\n",
+    "\n",
+    "# Initialize the list of number-of-features\n",
+    "nfeatures = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 22 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.580795\n",
+      "         Iterations 6\n",
+      "Beta = 0.0051387482643888574; p = 0.23900622040607855\n",
+      "Fitting 21 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.580797\n",
+      "         Iterations 6\n",
+      "Beta = 0.005152675106252487; p = 0.2377343267982288\n",
+      "Fitting 20 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.580995\n",
+      "         Iterations 6\n",
+      "Beta = 0.005331898719088635; p = 0.2217071971083846\n",
+      "Fitting 19 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581000\n",
+      "         Iterations 6\n",
+      "Beta = 0.0053208986178373986; p = 0.22265898791676864\n",
+      "Fitting 18 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581006\n",
+      "         Iterations 6\n",
+      "Beta = 0.005289272828990819; p = 0.2254160157908779\n",
+      "Fitting 17 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581044\n",
+      "         Iterations 6\n",
+      "Beta = 0.005298972805549763; p = 0.22454761130069922\n",
+      "Fitting 16 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581056\n",
+      "         Iterations 6\n",
+      "Beta = 0.005505392090815585; p = 0.20698360240201108\n",
+      "Fitting 15 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581103\n",
+      "         Iterations 6\n",
+      "Beta = 0.005158066962339109; p = 0.23705261121804322\n",
+      "Fitting 14 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581137\n",
+      "         Iterations 6\n",
+      "Beta = 0.005091582723623313; p = 0.2431324159874857\n",
+      "Fitting 13 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581178\n",
+      "         Iterations 6\n",
+      "Beta = 0.0046944228380368744; p = 0.2818180498188174\n",
+      "Fitting 12 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581212\n",
+      "         Iterations 6\n",
+      "Beta = 0.004663816556705156; p = 0.2849500934868445\n",
+      "Fitting 11 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581284\n",
+      "         Iterations 6\n",
+      "Beta = 0.004436956928535786; p = 0.30899125963824015\n",
+      "Fitting 10 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581587\n",
+      "         Iterations 6\n",
+      "Beta = 0.004633703041717222; p = 0.2878504007391891\n",
+      "Fitting 9 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.581726\n",
+      "         Iterations 6\n",
+      "Beta = 0.0045885401048239806; p = 0.2924924047538022\n",
+      "Fitting 8 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.583541\n",
+      "         Iterations 6\n",
+      "Beta = 0.00477422903055852; p = 0.2723687835236751\n",
+      "Fitting 7 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.589221\n",
+      "         Iterations 6\n",
+      "Beta = 0.003938069578800144; p = 0.3621641882243887\n",
+      "Fitting 6 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.598360\n",
+      "         Iterations 6\n",
+      "Beta = 0.0026332890950457404; p = 0.5383485770800843\n",
+      "Fitting 5 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.600242\n",
+      "         Iterations 6\n",
+      "Beta = 0.003135072518891824; p = 0.4629634385800454\n",
+      "Fitting 4 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.602868\n",
+      "         Iterations 6\n",
+      "Beta = 0.0030640823035650616; p = 0.47178870038200404\n",
+      "Fitting 3 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.609502\n",
+      "         Iterations 6\n",
+      "Beta = 0.002826516164181513; p = 0.5041269794316179\n",
+      "Fitting 2 variables...\n",
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.622069\n",
+      "         Iterations 6\n",
+      "Beta = 0.0018370791300488635; p = 0.6606869122821312\n"
+     ]
+    }
+   ],
+   "source": [
+    "while (rf):\n",
+    "    nfeatures.append(len(rf)+1)\n",
+    "    print(f\"Fitting {nfeatures[-1]} variables...\")\n",
+    "    fit = sm.Logit(y,X[['upm', 'intercept'] + rf]).fit()\n",
+    "    beta.append(fit.params[0])\n",
+    "    p.append(fit.pvalues[0])\n",
+    "    print(f\"Beta = {beta[-1]}; p = {p[-1]}\")\n",
+    "    rf = rf[:-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj8AAAG5CAYAAABhrVVvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xl8VOXZ//HPlT2EPYRN9h1URARccANt3bfWKm6t1lbbStVfn2r16W611i5qtVq17isufVSsWqsCVkXRIKiQEAiLbJEECCSQPbl+f8wJjjEJA2QySeb7fr3mxZxz7nOfa2ZC5sp97sXcHREREZF4kRDrAERERERak5IfERERiStKfkRERCSuKPkRERGRuKLkR0REROKKkh8RERGJK0p+ROKAmU01sxVmtsPMzjSzPmb2XzMrNbO/mNn/mtn9EdRzj5n9sjVibq/MzM1sRIyuPdrMFgWf65WxiEGkPVDyI9JAY19eZvYbM3s8eH6smdUFiUSpmeWZ2SXBsSHB+R81OL+XmVWZ2ZpmrmtmdqWZLTGznWa23syeNbMDW+Bl3QD8zd07u/sLwGXAZqCru/+Pu//e3b+3u0rc/Qfu/rt9DSZ4D9fvaz0RXsfN7K4G+98xs4ujff0YuBaY5+5d3P2OhgfNbJ6ZVQQ/u/WPw/flgmE/80n7Uo9Ia1LyI7J3Nrp7Z6Ar8DPgH2Y2Lux4hpkdELZ9PrB6N3X+FbgKuBLoCYwCXgBOaYF4BwNLG2zneHzMcroT+LaZDYlxHHtkL5OJhp9zY2YGSXD94729uE6LCZJ+fRdJq9IPnMg+8JAXgGIgPPl5DPhO2Pa3gUebqsfMRgJXAOe5+xx3r3T3Mnd/wt3/EJTpZmaPmlmRmX1mZr8I/9Iws++aWa6ZFZvZa2Y2ONi/EhgGvBT8pf9UENu1wfbx4S1bwTlHmtl8M9tmZuvqW0nM7GEzuzGs3KlmtjgoN9/MxocdW2NmPzWzT8xsu5k9bWZpZpYBvAr0D2t96N/g/TjMzD43s8SwfWeZ2SfB8ylmlm1mJWa2ycxubeZj2gY8DPy6ife+4Wv/UktG0FpyY/D6dpjZS2aWaWZPBNf/sJHE6mQzW2Vmm83sT5F8TsExN7MrzGwFsKKJeE83s6XBez7PzMYG++cA04C/BXGOauY9aazeMWb2uplttVBr5jlhx06x0O20kuDn4Tdhp/43+HdbfUtShO/pTWb2LlAGDAt+vh8wswIz2xC854lB+RFm9lbwc7TZzJ7ek9cm0pCSH5F9YGYJZnYW0B34NOzQ48AMM0sMvpy6AAuaqeo4YL27f9BMmTuBboQSmWMIJVT1t9vOBP4X+AaQBbwNPAXg7sOBtcBpwV/65wFPAH8Mtt9o8JoGEUpO7gzqmgAsbuS1TwQeBC4HMoF7gdlmlhpW7BzgRGAoMB642N13AicRtJ4Fj43hdbv7+4RabKaH7T4feDJ4/lfgr+7eFRgOPNPM+wZwE/BNMxu9m3JNmQFcBOwXXO894CFCLXS5fDWxOguYBEwEzgC+C81/TmHOBA7ly8k0wfmjgvJXB+e/QiipTXH36UF99S07yyN9cUFC+jqh97c3cB5wt5ntHxTZSejnrTuhlsgfBq8F4Ojg3+572JJ0EaHbr12Az4BHgBpgBHAw8HWg/lbs74D/AD2AAYR+NkX2mpIfkb3T38y2Eeo382vgInfPCzu+HsgDjifUytJkq08gEyho6mDwF/C5wPXuXurua4C/EPoCgVACcrO757p7DfB7YEJ4q8IeuAB4w92fcvdqd9/i7l9JfoDvA/e6+wJ3r3X3R4BK4LCwMne4+0Z33wq8RCiRitRThL6EMbMuwMl8kShUAyPMrJe77wiSpSa5++fAPYT6Pu2Nh9x9pbtvJ5QYrnT3N4L3+llCX9bhbnH3re6+Fri9/nUQ2ed0c3BueSNxnAu87O6vu3s18GcgHThiD17LHUGr0Tb7om/aqcAad3/I3Wvc/SPgn8DZAO4+z90/dfc6d/+E0OdwzB5cszEPu/vS4H3oSSghvtrdd7p7IXAboaQTQp/3YKC/u1e4+zv7eG2Jc0p+RL6qFkhusC+Z0C/gehvdvbu793T3Ce4+q5F6HgUuJvTF93gjx8NtAfo1c7wXkELoL+R6nxFqiYDQF8Nf67/UgK2AhR3fEwOBlRGUGwz8T9gX6bbg3PBbWJ+HPS8DOu9BHE8C3whakr4BfOTu9a//UkJ9opYFt51OjaC+W4ATzOygPYih3qaw5+WNbDd8XevCnn/GF+9JJJ9T+LkN9SfsZ8Dd64Lye/I5Xxn87HZ394lhcR3a4LO8AOgLYGaHmtlcC91y3Q78gNDP5L4If52DCf0fKwi7/r2EWqEg1JHbgA+CW37f3cdrS5xT8iPyVWuBIQ32DeXLiUck/knoFsGqsC/tprwJDDCzSU0c38wXf/3WGwRsCJ6vAy4P+1Lr7u7p7j5/D2Our2t4hOVuanDNTu7e8DZOY3bb0drdcwi95yfx5VteuPuK4PZdb0JJzXPBrZvm6ttCqBWm4Wi1nUCnsO2+EcS/OwPDng8C6m/rRfI5NffebCTsZ8DMLLjWhibPiMw64K0GcXV29x8Gx58EZgMD3b0boVY0aybeSN7T8PPWEWo17BV2/a7uvj+EWu7c/fvu3p9Q69ndFqPpBKRjUPIj8lVPA78wswFBn57jgdOA5/akkqBvy3S+6LfQXNkVwN3AUxYanp1ioc7BM8zsOnevJdSv5SYz6xLcJvkJX7Qo3QNcX99HI+g8+q09iTfME8DxZnaOmSUFnXsbu131D+AHQauAmVlG0DG2SwTX2ARkmlm33ZR7ktDot6MJ3V4CwMwuNLOsoOVjW7C7NoLr3kroFtHYsH2LgaPNbFAQz/UR1LM715hZDzMbSGgEX30H3X39nJ4BTjGz48wsGfgfQknD3iS54f4FjDKzi8wsOXhMru9MTahfzlZ3rzCzKYSS0XpFQB2hvmj19ug9dfcCQn16/mJmXYP/d8PN7BgAM/uWmQ0IihcTSpwi+bxFGqXkR+SrbiD0ZfIOoV+0fwQucPcle1qRu2e7eyS3kCD0Jf834C5CX+grCXWcfSk4/mNCf1GvCmJ7klCHY9z9eUItILPMrARYQqjFZI8F/VROJvTFupXQF9lXbhW5ezahfj9/I/Q+5RO6zRfJNZYR6jeyKrjN0b+Jok8BxwJz3H1z2P4TgaVmtoNQ5+cZ7l4RwXVLCH2ePcP2vU4oOfkEWEgoEdhXLwZ1LQZeBh4IrrVPn1PQr+xCQh1+NxNKyk9z96p9CdbdSwl1MJ5BqHXp8yDO+s7rPwJuMLNS4FeEdTB39zJCHcrfDT7Lw/byPf02oVu7OYR+np7ji1vBk4EFwec9G7jK3Xc3dYRIk8zjYpoPERERkRC1/IiIiEhcUfIjIiIicUXJj4iIiMQVJT8iIiISV+J6Fd5evXr5kCFDYh2GiIiItICFCxdudves3ZWL6+RnyJAhZGdnxzoMERERaQFmFtFktLrtJSIiInFFyY+IiIjEFSU/IiIiEleU/IiIiEhcUfIjIiIicUXJj4iIiMQVJT8iIiISV5T8iIiISFxR8iMiIiJxRcmPiIiIxBUlPyIiIhJXlPyIiIhIXFHyIyIiInElqsmPmZ1oZnlmlm9m1zVyPNXMng6OLzCzIWHHrg/255nZCWH715jZp2a22Myyw/b/xsw2BPsXm9nJ0XxtIiIi0j4lRatiM0sE7gK+BqwHPjSz2e6eE1bsUqDY3UeY2QzgFuBcMxsHzAD2B/oDb5jZKHevDc6b5u6bG7nsbe7+52i9JhERaZq7s62smh4ZKbEORaRZ0Wz5mQLku/sqd68CZgFnNChzBvBI8Pw54Dgzs2D/LHevdPfVQH5Qn4iItFF/fXMFE298nfvfXoW7xzockSZFM/nZD1gXtr0+2NdoGXevAbYDmbs514H/mNlCM7usQX0zzewTM3vQzHo0FpSZXWZm2WaWXVRUtDevS0REGvhobTF3zsknMyOFG1/O5ZcvLqGmti7WYYk0KprJjzWyr+GfAk2Vae7cqe4+ETgJuMLMjg72/x0YDkwACoC/NBaUu9/n7pPcfVJWVtZuXoKIiOzOzsoafvL0Yvp2TePNnxzL5ccM4/H313LJwx9SUlEd6/BEviKayc96YGDY9gBgY1NlzCwJ6AZsbe5cd6//txB4nuB2mLtvcvdad68D/oFuk4mItIobX87ls61l3HrOQXTrlMz1J43l5m8cyHsrt3D23+ezbmtZrEMU+ZJoJj8fAiPNbKiZpRDqwDy7QZnZwHeC52cDczx0o3g2MCMYDTYUGAl8YGYZZtYFwMwygK8DS4LtfmH1nlW/X0REoufN3E089cFaLjt6GIcOy9y1/7wpg3j4kikUbK/grLvfZdHa4hhGKfJlUUt+gj48M4HXgFzgGXdfamY3mNnpQbEHgEwzywd+AlwXnLsUeAbIAf4NXBGM9OoDvGNmHwMfAC+7+7+Duv4YDIH/BJgG/L9ovTYREYEtOyr52T8/YWy/rvzka6O+cvzIkb14/kdHkJ6SyIz73ueVTwtiEKXIV1k898ifNGmSZ2dn776giIh8ibtz2WMLeSuviJd+fCSj+3ZpsuzmHZVc9mg2H63dxrUnjuaHxwwnNLBXpGWZ2UJ3n7S7cprhWURE9tiz2et5PWcT1544utnEB6BX51Se/P5hnHZQf/747zx+9s9PqKrRSDCJnahNcigiIh3T2i1l/PalpRw+LJPvTh0a0TlpyYncMWMCQ3tlcMebK1i3tZx7LjyEbp2SoxytyFep5UdERCJWW+f8v2cWk5Bg/Pmcg0hIiPz2lZnxk6+N4tZzDiL7s62cdfe7rNm8M4rRijROyY+IiETsnrdWsvCzYn53xgHs1z19r+r4xsQBPH7poWwtq+Ksu9/lwzVbWzhKkeYp+RERkYgs2bCd215fzqnj+3HGhP77VNehwzJ5/kdT6dEphQv+sYAXFm1ooShFdk/Jj4iI7FZFdS1XP72YzM4p3HjmAS0yWmtorwz+70dHMHFwd65+ejG3vb5ca4JJq1DyIyIiu/WHV5eRX7iDP3/rILp3arlV27t3SuHR7x7KNycO4K9vruDqpxdTUV3bYvWLNEajvUREpFlvryji4flruPiIIRw1suXXRExJSuDP3xrPsKwM/vRaHhuKy7n3okPI7Jza4tcSAbX8iIhIM7aVVfHTZz9mRO/OXHfSmKhdx8y4YtoI/nb+wXy6YTtn3T2f/MIdUbuexDe1/IiISKPcnZ+/sIQtO6p44DuTSUtOjPo1Tx3fn/7d07ns0Wy+cfe73HPhIRwxolfUr9ua3J3Kmjp2VtZQVlVLWVUtO6tqKK+q/dK+sqoadlbWUlZdQ1llWJmqWsqraqiqdS44dBDfOmSAZszeQ0p+RESkUbM/3sjLnxRwzQmjOWC/bq123YmDevD8j6by3Yc/5NsPfsDvzzqQcyYPbLXr7w13Z/OOKtYVl7Fua/2jnHXFZWwrq6as6stJTd0e9OtOSUogIyWRTilJdEpJpFNqEp2SE9lRWc21z33C/PzN3HjWgXRO1Vd6pPROiYjIV2zYVs4vXljCIYN7cPnRw1r9+gN7duKfPzqCK574iGv/+QmrNu/k2hNG79Gkii1tZ2VNkNyUs25rGWu3lrG+OPTvuq3llDfoqN2rcyoDe6bTv3vaF4lLShIZqYmkpySSEbavU2r49hf7OiUnkpTYeA+V2jrn7rn53PbGcj5ev52/nX8w+/dvvSS1PdPCplrYVETkS+rqnAvuX8An67fx6lVHMyizU8xiqa6t49ezl/LkgrVMGNidAT3SSU8OJQ/pKYmh58F2WnIocajfl5by1e305ESSm0gmamrrKNhesSuxWVdcxtog0Vm3tYwtO6u+VD4jJZGBPTuFHj06Mahn+q7tAT3S6ZTSOu0LC1Zt4cpZiyjeWc0vTh3LRYcNjtvbYJEubKrkR8mPiMiX3P/2Km58OZdbvnkg504eFOtwcHcemb+GZxeup7y6lvKq2l3/Vu7FAqnJiUZaWNKUnpzIzqoaNm6roDbsflRSgtG/ezoDe6YzqGcnBvToxKBdyU46PTNS2kySsXVnqGP6nGWFnLh/X245ezzd0uNv3TQlPxFQ8iMi8mV5n5dy2p3vcMzoLO676JA28+XelNo6p6L6i2SoojrUr6Y82FdR9cV2RVCmLKxseVA+PTkxSGzSd7Xk9OuW1uQtp7aors558N3V/OHVZfTpmsad5x/MxEE9Yh1Wq4o0+VGfHxERAaCypparZi2ia3oSN3/jwDaf+AAkJhgZqUlkqLMvCQnG944axqQhPZn55Eecc897XHPCaL5/1LCY9pVqi9pPSisiIlF16+vLWfZ5Kbd8czy9NMFguzVhYHdevvIovr5/H25+dRnffeRDtuyojHVYbYqSHxERYcGqLdz331WcN2UQx43tE+twZB91S0/mrvMn8rszD2D+yi2cfMfbvLdyS6zDajOU/IiIxLmSimp+8szHDO7ZiV+cMjbW4UgLMTMuOmwwL/xoKhkpSVxw//vc/sbyL3XqjldKfkRE4txvZ+dQsL2cW8+doL4zHdC4/l156cdHcuaE/bj9jRVccP/7bCqpiHVYMaXkR0Qkjr36aQH//Gg9M6eNiLuRQfEkIzWJW8+dwJ+/dRAfr9vOyX99m3l5hbEOK2aU/IiIxKnCkgquf/5Txg/oxo+PGxnrcKQVnH3IAF768VSyuqRy8UMfcvOruVTX7vlcSe2dkh8RkTjk7lzz3CdUVNdy27kTmpz1WDqeEb278MIVU7ng0EHc+9Yqzrn3PdZtLYt1WK1KP+0iInHo8fc/463lRfzvyWMZntU51uFIK0tLTuSmsw7krvMnkr9pB6fc8Tb/XvJ5rMNqNUp+RETizMqiHdz0Si5Hj8riosMGxzociaFTxvfj5SuPYkivDH7w+EJ+/eISKhos0NoRKfkREYkT7s7yTaX8v6cXk5acyJ/OHt8uZnGW6BqU2YnnfnAElx45lEfe+4xv/n0+qzfvjHVYUaUxjSIiHdjWnVW8k7+Zt5cX8faKzXxeUkGCwd0XTKRP17RYhydtREpSAr88dRyHD8vkp899zAm3/5d+3dLokpZE59QkuqQl0yUtia5pycH2F/s6pyXRNXw7NYmMlKQ2vaSGkh8RkQ6kqqaOj9YW8/aKULLz6YbtuIdm/D1yRC+OGtmLo0ZlsV/39FiHKm3Q8eP68MqVR3H/26vZsrOS0ooaSiuqWbe1bNfzHZU17G6eRDNCSVJY4hRKlELPrz9pDF3SYrfqvJIfEZF2zN1Zs6WM/y4v4u0VRby3cgs7q2pJTDAmDurO/zt+FEeN7MX4Ad1JbMN/iUvb0b97Or86bVyTx92dsqraXclQaWXNF88ratgRPC+pCO3fURnav3lHFWu2lFFaUc3/nhzbmcSV/IiItDPby6uZn7+Z/67YzNsrilhfXA7AoJ6dOGvifhw1MovDh2fSNYZ/WUvHZWZkpCaRkZpE327t89apkh8RkTaupraOj9dv39W6s3jdNuo8dFvhiOGZXH7McI4e2YvBmRmxDlWkXVDyIyLSBhVsL2fusiL+u7yId1duprSiBjM4aEB3Zk4bwVGjspgwsLsmJxTZC0p+RETamFVFOzjljncor66lf7c0TjmwH0eNzGLqiEy6d0qJdXgi7Z6SHxGRNsTd+dWLS0lKMF658ijG9uuiuXhEWpjaS0VE2pCXPy3gnfzN/PSE0Yzr31WJj0gUKPkREWkjSiuqueGlHPbv35ULteyESNTotpeISBtx+xsrKNpRyb0XHaI5eUSiSC0/IiJtQM7GEh6ev4bzpgzi4EE9Yh2OSIcW1eTHzE40szwzyzez6xo5nmpmTwfHF5jZkLBj1wf788zshLD9a8zsUzNbbGbZYft7mtnrZrYi+Fe/PUSkXairc3754hK6pSdz7QmjYx2OSIcXteTHzBKBu4CTgHHAeWbWcL7sS4Fidx8B3AbcEpw7DpgB7A+cCNwd1FdvmrtPcPdJYfuuA95095HAm8G2iEib99zC9Sz8rJjrTxqjoewirSCaLT9TgHx3X+XuVcAs4IwGZc4AHgmePwccZ6GhDWcAs9y90t1XA/lBfc0Jr+sR4MwWeA0iIlFVvLOKm1/NZfKQHnxz4oBYhyMSF6KZ/OwHrAvbXh/sa7SMu9cA24HM3ZzrwH/MbKGZXRZWpo+7FwR1FQC9GwvKzC4zs2wzyy4qKtqrFyYi0lL++NoySipq+N2ZB5CgTs4irSKayU9j/4s9wjLNnTvV3ScSup12hZkdvSdBuft97j7J3SdlZWXtyakiIi3qo7XFPPXBOr47dQhj+naNdTgicSOayc96YGDY9gBgY1NlzCwJ6AZsbe5cd6//txB4ni9uh20ys35BXf2AwhZ8LSIiLaqmto5fPL+Evl3TuOr4UbEORySuRDP5+RAYaWZDzSyFUAfm2Q3KzAa+Ezw/G5jj7h7snxGMBhsKjAQ+MLMMM+sCYGYZwNeBJY3U9R3gxSi9LhGRffbY+5+RU1DCr04bR+dUTbkm0pqi9j/O3WvMbCbwGpAIPOjuS83sBiDb3WcDDwCPmVk+oRafGcG5S83sGSAHqAGucPdaM+sDPB9M954EPOnu/w4u+QfgGTO7FFgLfCtar01EZF8UllTwl/8s5+hRWZx0QN9YhyMSdyzU0BKfJk2a5NnZ2bsvKCLSgq58ahH/Xvo5/7n6aIb0yoh1OCIdhpktbDANTqM0w7OISCt6N38zsz/eyA+PGa7ERyRGlPyIiLSSyppafvniEgZnduKHxw6PdTgicUu97EREWsn9b69mVdFOHrpkMmnJibs/QUSiQi0/IiKtYN3WMu54cwUnHdCXaaMbnYNVRFqJkh8RkVbw25eWkphg/PLUhkscikhrU/IjIhJlr+ds4o3cQq4+fiT9u6fHOhyRuKfkR0QkisqqavjN7KWM6tOZS6YOjXU4IoI6PIuIRNXf5uSzYVs5z1x+OMmJ+ntTpC3Q/0QRkSjJLyzlH2+v4psTBzBlaM9YhyMiASU/IiJR4O784oUlpCcncv3JY2IdjoiEUfIjIhIFLy7eyPurtnLtiWPo1Tk11uGISBglPyIiLWx7eTU3vpzLQQO6cd6UQbEOR0QaUIdnEZEWdut/8tiys5KHLp5MYoLFOhwRaUAtPyIiLejT9dt57P3PuOiwwRw4oFuswxGRRij5EYmBotJKqmrqYh2GtLDaOucXL3xKz4wU/ufro2Mdjog0QcmPSCsrqahm2p/nceZd7/LZlp2xDkda0KwP1/Lx+u38/JSxdEtPjnU4ItIEJT8irezdFZvZUVnDyqIdnHrnO7y29PNYhyQtYPOOSv747zwOHdqTMyfsF+twRKQZSn5EWtncvEK6pCXx2tVHM7RXBpc/tpCbX8mlpla3wdqzP7y6jJ2VNdx45gGYqZOzSFum5EekFdXVOXPzijh6VBZDemXw7A8O54JDB3Hvf1dx/j8WUFhSEesQZS98sHorzy1cz/ePHsbIPl1iHY6I7IaSH5FWlFNQQlFpJdNG9wYgNSmRm846kNvOPYhPN2zn5Dve4b2VW2IcpeyJ6to6fvnCEvbrns6Pp4+IdTgiEgElPyKtaO6yQgCOGZX1pf1nHTyAF2dOpWt6Ehfc/z53z8unrs5jEaLsoYffXUPeplJ+fdo4OqVo6jSR9kDJj0grmptXyEEDupHV5avLHYzq04XZM4/k5AP78cd/5/H9R7PZXlYdgyglUgXby7ntjeUcN6Y3XxvXJ9bhiEiE9GeKSCvZurOKReu2ceX0kU2W6ZyaxJ3nHczkIT258eUcTrnzbf5+wSGaLK8NqKiuZX1xOeuLy1hfXM664jLeWbGZ2jrnN6fvr07OIu2Ikh+RVvL2iiLcYdqY3s2WMzO+c8QQDhzQjZlPfMQ3/z6fX58+jvOnDNIXbBRV1tRSsK2CdfXJzdayXcnOuuJyikorv1Q+OdHo3z2d3515AAN7dopR1CKyN5T8iLSSucsKycxIYfx+kbXiTBzUg39deRRXP72Ynz+/hIVrirnxrAPUr2QvVdfW8fn2iq8kNeuLy1i3tZxNpRV4WDerxASjf/c0BvboxLTRWQzo0YmBPdMZ0KMTA3qk06dLGglat0ukXdJvUZFWUFvnvLW8iGmje+/RF2bPjBQevngyd87J5/Y3l7N0Ywl3XziR4Vmdoxhtx1FX5/zpP3nMXryRz0sqqA3rRJ5g0K9bOgN6pDN1RC8G9EhnYM9QYjOgRzp9u6aRlKhukSIdkZIfkVbw8fptFJdVc+xubnk1JiHBuOr4kUwc3J2rZi3m9Dvf4Zazx3Pq+P5RiLTjqKmt45rnPuH5RRs4bkxvvjFxPwYGrTYDe3aib7c0kpXciMQlJT8irWDuskISDI4e2Wuv6zhqZBb/+vGRzHzyI2Y+uYjsNcX878ljSUnSF3hDFdW1/PipRbyes4mffn0UV0wbof5SIrKLkh+RVjA3r5CJg3rQvVPKPtXTv3s6sy47nJtfzeWhd9fw8fpt3HX+RPp3T2+hSL+wdWcVuQUl5GwsIaeghNyCEkrKq7nhjAM4vg0P695RWcNlj2Yzf+UWbjhjf759+JBYhyQibYySH5EoKyypYMmGEq45YXSL1JeSlMCvT9ufSYN7cu1zH3Pqne9w+7kTOLrBxImRqqtz1m4tIycs0cnZWMLnYUtt9O2axth+oWUbvv9YNj/9+mh+dOzwNteasq2siosf+pBPN2zn1nMO4hsTB8Q6JBFpg5T8iETZvOVFALuWtGgpp4zvx5h+XfjR4x/xnYc+4KrjRnLl9JHNdqgur6olb1Ppl1p0lhWUsLOqFgiNcBqR1ZnDh2cytl8XxvXrxth+XcjsHJqUsaK6lp/98xP+9FoeORtL+NO3xreZ0WeFJRVc9MAHrN68k7svmMgJ+/eNdUgi0ka1jd9aIh3YvLxC+nRN3dVy0pKGZ3XmhSum8vMXPuX2N1bw0dpt3H7uBHpmpFBUWrmrFSe3IJTorCraQf2Ap86pSYzr15VvTRq4K9EZ2aczacmJTV4vLTmR28+dwLh+XfnDv5exavNO7rvokJjPc7NuaxkXPrDaCpqaAAAgAElEQVSAotJKHrpkMlNH7H3fKhHp+Mw9ftcPmjRpkmdnZ8c6DOnAqmvrmHjD65wyvh9/+Ob4qF3H3Zn14Tp+PXspXVKTSEiwL03Kt1/3dMb268q4/l0Z1y/0GNAjfZ/mqZmXV8iPn1pEcmICd18wkcOGZbbES9lj+YWlXHj/B5RX1/LQJZOZOKhHTOIQkdgzs4XuPml35dTyIxJFCz8rprSyhmNb+JZXQ2bGeVMGceB+3bj19eX06JSyK9EZ26/LPne0bsyxo3vz4hVT+f6j2Vx4/wJ+fdo4LjxscKv2A/p0/Xa+/eACkhITePrywxjTt2urXVtE2i8lPyJRNDevkOREY+qI1mkVOWC/bjx48eRWuRbAsKzOPH/FVK6etZhfvriUnIISfnv6Aa0y/H7Bqi1c+kg23dKTeeJ7hzKkV0bUrykiHYMmCBGJonnLipg8pCdd0pJjHUrUdE1L5h/fnsQV04bz1AfrOP8f739lHayWNmfZJr794Af06ZrKcz88XImPiOwRJT8iUbJhWzl5m0pbfJRXW5SYYFxzwhjuPO9glmzczul/e4dP1m+LyrVmf7yRyx5dyMg+nXnm8sPp163l5zgSkY5NyY9IlMxdVgjAtDF7N/9Oe3TaQf355w+PIMGMb93zHi8s2tCi9T+5YC1XzVrExME9ePL7h+0agi8isieimvyY2Ylmlmdm+WZ2XSPHU83s6eD4AjMbEnbs+mB/npmd0OC8RDNbZGb/Ctv3sJmtNrPFwWNCNF+byO7MyytkQI/0uFuEdP/+3Zg9cyoHDezO1U8v5uZXcr+0oOjeuvetlfzv859y7KgsHv3uFLp24FuJIhJdUUt+zCwRuAs4CRgHnGdm4xoUuxQodvcRwG3ALcG544AZwP7AicDdQX31rgJyG7nsNe4+IXgsbtEXJLIHKqpreTd/C9PH9G5zsyC3hszOqTzxvUO56LDB3PvfVXz34Q/ZXla9V3W5O3/89zJufnUZp47vx70XTWp2LiIRkd2JZsvPFCDf3Ve5exUwCzijQZkzgEeC588Bx1nom+IMYJa7V7r7aiA/qA8zGwCcAtwfxdhF9skHq7dSXl0bF/19mpKcmMDvzjyA3591IPNXbubMu98lv7B0j+qoq3N++eIS7p63kvOmDOKvMw7WQq4iss+i+VtkP2Bd2Pb6YF+jZdy9BtgOZO7m3NuBa4G6Rq55k5l9Yma3mVmjnQHM7DIzyzaz7KKioj18SSKRmZtXSGpSQswm/mtLzj90EE9+/zBKK6o58675vJm7KaLzqmvr+Mkzi3n8/bVcfvQwfn/WASTuw6SMIiL1opn8NPZbquGN/6bKNLrfzE4FCt19YSPHrwfGAJOBnsDPGgvK3e9z90nuPikrK346okrrmpdXxOHDM0lP0e0ZgMlDejJ75pEM6dWJ7z2azV1z82ludvmK6lp++PhHvLB4I9ecMJrrThoTl7cPRSQ6opn8rAcGhm0PADY2VcbMkoBuwNZmzp0KnG5mawjdRptuZo8DuHuBh1QCDxHcJhNpbas372T15p1xfcurMf27p/Ps5Udw+kH9+dNrecx8ahFlVTVfKbejsoZLHvqQN3I38bsz9ueKaSOU+IhIi4pm8vMhMNLMhppZCqEOzLMblJkNfCd4fjYwx0N/Ds4GZgSjwYYCI4EP3P16dx/g7kOC+ua4+4UAZtYv+NeAM4ElUXxtIk2alxcMcVfy8xXpKaGFUa8/aQyvfFrA2X9/j/XFZbuOF++s4oL7F/DBmq3cdu5BXHT4kNgFKyIdVtSWt3D3GjObCbwGJAIPuvtSM7sByHb32cADwGNmlk+oxWdGcO5SM3sGyAFqgCvcvXY3l3zCzLII3TJbDPwgKi9MZDfmLCtkWFYGgzJju9J5W2VmXH7McEb17cKVTy3i9L+9y90XTGRorwwuemABa7aUcc+Fh/C1cX1iHaqIdFBa1V2ruksLKquqYcJvX+eiwwfzy1MbzuwgDa0q2sH3Hs1m7ZYyMjunUFpRw/3fnsQRI3rFOjQRaYciXdVdY0ZFWtD8/C1U1dbplleEhmV15oUrpnLMqCyqa50nvneoEh8RiTqt6i7SgubmFZKRksjkoT1iHUq70TUtmQcunkx1bR3Jifp7TESiT79pRFqIuzMvr4ipI3qRmqQh7ntKiY+ItBb9thFpISsKd7BhWznTxuiWl4hIW6bkR6SF1K/ifuxoTZ4pItKWKfkRaSFz8woZ07cL/bqlxzoUERFphpIfkRZQUlFN9ppi3fISEWkHlPyItIB3Vmymps41xF1EpB1Q8iPSAuYuK6RLWhITB3WPdSgiIrIbSn5E9lFdnTNveRFHj8oiScO1RUTaPP2mFtlHOQUlFJVWMl23vERE2gUlPyL7qH6I+zEa4i4i0i4o+RHZR3PzCjloQDd6dU6NdSgiIhIBJT8i+2DrzioWrdvGsbrlJSLSbij5EdkHb68owh3N7yMi0o4o+RHZB3OWFZKZkcL4/brFOhQREYmQkh+RvVRb57y1vIhjRmWRkGCxDkdERCKk5EdkLy1et41tZdUcq1teIiLtipIfkb00L6+QBIOjR/aKdSgiIrIHlPyI7KW5eYUcMrgH3TulxDoUERHZA0p+RPZCYUkFSzaUaIi7iEg7pORHZC/MW14EoFXcRUTaISU/InthXl4hfbqmMrZfl1iHIiIie0jJj8geqq6t4+3lm5k2ujdmGuIuItLeKPkR2UPZa4opraxRfx8RkXZKyY/IHpqXV0hyojF1RGasQxERkb2g5EdkD83NK2TykJ50SUuOdSgiIrIXlPyI7IH1xWUs37RDo7xERNoxJT8ie2BeXjDEXUtaiIi0W0p+RPbAvLxCBvZMZ3hWRqxDERGRvaTkRyRCFdW1vJu/RUPcRUTaOSU/IhH6YPVWyqtr1d9HRKSdU/IjEqG5eYWkJiVw2DANcRcRac+U/IhEaO6yQg4fnkl6SmKsQxERkX2g5EckAqs372TNljLd8hIR6QB2m/yY2WOR7BPpyOYuKwS0iruISEcQScvP/uEbZpYIHBKdcETaprl5hQzLymBQZqdYhyIiIvuoyeTHzK43s1JgvJmVBI9SoBB4sdUiFImxsqoaFqzaynS1+oiIdAhNJj/ufrO7dwH+5O5dg0cXd8909+sjqdzMTjSzPDPLN7PrGjmeamZPB8cXmNmQsGPXB/vzzOyEBuclmtkiM/tX2L6hQR0rgjpTIolRZHfm52+hqrZOszqLiHQQu73t5e7Xm9l+ZnaEmR1d/9jdecHtsbuAk4BxwHlmNq5BsUuBYncfAdwG3BKcOw6YQeiW24nA3UF99a4CchvUdQtwm7uPBIqDukX22dy8QjJSEpk0pEesQxERkRYQSYfnPwDvAr8ArgkeP42g7ilAvruvcvcqYBZwRoMyZwCPBM+fA46z0NS5ZwCz3L3S3VcD+UF9mNkA4BTg/rAYDZge1EFQ55kRxCjSLHdnXl4RU0f0IjVJQ9xFRDqCpAjKnAWMdvfKPax7P2Bd2PZ64NCmyrh7jZltBzKD/e83OHe/4PntwLVAl7DjmcA2d69ppLzIXltRuIMN28qZOX1ErEMREZEWEslor1VA8l7U3djiRx5hmUb3m9mpQKG7L9yLa4UKml1mZtlmll1UVNRYEZFd5gRD3I8dnRXjSEREpKVE0vJTBiw2szeBXa0/7n7lbs5bDwwM2x4AbGyizHozSwK6AVubOfd04HQzOxlIA7qa2ePARUB3M0sKWn8au1Z93PcB9wFMmjSp0QRJpN7cZYWM6duFft3SYx2KiIi0kEhafmYDvwPmAwvDHrvzITAyGIWVQqgD8+xG6v5O8PxsYI67e7B/RjAabCgwEvjA3a939wHuPiSob467XxicMzeog6BODceXfVJSUU32Z8Ua5SUi0sHstuXH3R8xs3RgkLvnRVpx0IdnJvAakAg86O5LzewGINvdZwMPAI+ZWT6hFp8ZwblLzewZIAeoAa5w99rdXPJnwCwzuxFYFNQtstfeWbGZ2jrXrM4iIh2MhRpNmilgdhrwZyDF3Yea2QTgBnc/vTUCjKZJkyZ5dnZ2rMOQNuqaZz/mtaWf89Evv0ZSopbBExFp68xsobtP2l25SH6j/4bQMPNtAO6+GBi6T9GJtAPvrdrC1BG9lPiIiHQwkfxWr3H37Q32qaOwdGjby6tZX1zOgQO6xToUERFpYZGM9lpiZucDiWY2EriSUOdnkQ4rt6AEgHH9usY4EhERaWmRtPz8mNAyE5XAU0AJcHU0gxKJNSU/IiIdVySjvcqAnwcPkbiQs7GEXp1TyOqSGutQRESkhTWZ/JjZ7e5+tZm9RCN9fDrCaC+RpuR+XsLYfl0JLRsnIiIdSXMtP48F//65NQIRaSuqa+tY/vkOLpk6JNahiIhIFDSZ/IStn5UNlLt7HYCZJQK6FyAd1qqinVTV1jFW/X1ERDqkSDo8vwl0CttOB96ITjgisZdTEJrZYVx/JT8iIh1RJMlPmrvvqN8InndqprxIu5ZbUEpKUgLDemXEOhQREYmCSJKfnWY2sX7DzA4ByqMXkkhs5WwsYXSfLprZWUSkg4pkksOrgWfNbGOw3Q84N3ohicSOu5NbUMJxY7WYqYhIRxXJPD8fmtkYYDRgwDJ3r456ZCIxUFhayZadVZrcUESkA2tunp/p7j7HzL7R4NBIM8Pd/y/KsYm0upxgZmeN9BIR6biaa/k5GpgDnNbIMQeU/EiHk7MxSH400ktEpMNqLvkpDv59wN3faY1gRGItt6CEAT3S6ZqWHOtQREQkSpobznJJ8O8drRGISFuQU1Ci/j4iIh1ccy0/uWa2BuhtZp+E7TfA3X18VCMTaWVlVTWs3ryT08b3j3UoIiISRc0tb3GemfUFXgO0iKl0eHmfl+KumZ1FRDq65kZ7venux5nZa+7+WWsGJRILuQWlALrtJSLSwTV326ufmR0DnGZmTxG63bWLu38U1chEWllOwXa6pCYxoEd6rEMREZEoai75+RVwHTAAuLXBMQemRysokVjILShlbL+umNnuC4uISLvVXJ+f54DnzOyX7v67VoxJpNXV1YWWtThn0sBYhyIiIlEWycqNN5nZhWb2KwAzG2RmU6Icl0irWru1jLKqWsb26xLrUEREJMoiSX7uAg4Hzgu2S4N9Ih1G/bIW4/p1i3EkIiISbZGs6n6ou080s0UA7l5sZilRjkukVeUWlJCYYIzs0znWoYiISJRF0vJTbWaJhDo5Y2ZZQF1UoxJpZTkbSxielUFacmKsQxERkSiLJPm5A3ge6GNmNwHvAL+PalQirSy3oEQruYuIxInd3vZy9yfMbCFwXLDrTHfPjW5YIq1nW1kVG7dXaHJDEZE4EUmfH4BUvpjkUP19pEOp7+yslh8Rkfiw29teZnYV8ASQBfQGHjezH0c7MJHWkrNRyY+ISDyJpOXnUkIjvnYCmNktwHvAndEMTKS15BaUktUllawuqbEORUREWkEkHZ4NqA3brqXBOl8i7VlOQYn6+4iIxJFIWn4eAhaY2fPB9pnAA9ELSaT1VNXUkV9YyjGjsmIdioiItJJIRnvdambzgCMJtfhc4u6Loh2YSGvIL9xBda0zrr9afkRE4kWTyY+ZTQZ6ufur7v4R8FGw/3QzS3D3ha0VpEi05O5a1kJreomIxIvm+vz8CWhsPp+c4JhIu5dTUEJacgJDe2lZCxGReNFc8pPp7msa7nT3fCAzahGJtKLcghJG9+lCYoL68IuIxIvmkp/0Zo5ltHQgIq3N3UMjvdTfR0QkrjSX/LxhZjeZ2Zf+JDaz3wJzIqnczE40szwzyzez6xo5nmpmTwfHF5jZkLBj1wf788zshGBfmpl9YGYfm9nSIJb68g+b2WozWxw8JkQSo8Svz0sq2FZWrckNRUTiTHOjvf4HuB/IN7PFwb6DgGzge7urOFgJ/i7ga8B64EMzm+3uOWHFLgWK3X2Emc0AbgHONbNxwAxgf6A/oURsFFAJTHf3HWaWDLxjZq+6+/tBfde4+3ORvXSJd/UzO2uOHxGR+NJk8hPM6HyemQ0jlIQALHX3VRHWPQXIry9vZrOAMwh1mK53BvCb4PlzwN+ClqYzgFnuXgmsNrN8YIq7vwfsCMonBw+PMB6RL6kf6TVGyY+ISFzZ7QzP7r7K3V8KHpEmPgD7AevCttcH+xot4+41wHZCnambPNfMEoOWqELgdXdfEFbuJjP7xMxuM7NG1yows8vMLNvMsouKivbg5UhHk1NQwuDMTnROjXR9XxER6QgiWd5ibzU2fKZhK01TZZo8191r3X0CMACYYmYHBMevB8YAk4GewM8aC8rd73P3Se4+KStLs/rGs9yCUsb2VauPiEi8iWbysx4YGLY9ANjYVBkzSwK6AVsjOdfdtwHzgBOD7QIPqSS0JMeUlnoh0vHsrKxhzZadGuklIhKHmkx+zKxnc48I6v4QGGlmQ80shVAH5tkNyswGvhM8PxuY4+4e7J8RjAYbCowEPjCzLDPrHsSXDhwPLAu2+wX/GqH1x5ZE9hZIPFr2eSnuaKSXiEgcaq6zw2ZCLTA1wXb4rSgHhjVXsbvXmNlM4DUgEXjQ3Zea2Q1AtrvPJrRA6mNBh+athBIkgnLPEOocXQNc4e61QYLzSDCSLAF4xt3/FVzyCTPLCuJcDPwgsrdA4lFO/bIWavkREYk7zSU/dwLHAu8CTwHvBK0yEXP3V4BXGuz7VdjzCuBbTZx7E3BTg32fAAc3UX76nsQm8S23oISuaUn075YW61BERKSVNXnby92vAiYAzwIXAYvM7I/BbSiRdi1nYwlj+3WlwRyeIiISB5rt8Bx0IJ4LXAvcA1xCqJ+NSLtVW+fkfV6qW14iInGqydteZpZBaLLBc4Es4P+Aie6+rqlzRNqDNVt2Ul5dq87OIiJxqrk+P4XACkL9ffIJdXKebGaTAdz9/6IfnkjLq5/ZWctaiIjEp+aSn2cJJTxjgkc4J9QSJNLu5GwsISnBGNmnc6xDERGRGGhuba+LWzEOkVaTW1DCiN6dSU1KjHUoIiISA81NcniomX1sZjvM7D0zG9uagYlES05Bifr7iIjEseZGe90F/JTQQqO3Are3SkQiUbRlRyWbSirV30dEJI41l/wkuPvr7l7p7s8SGvEl0q7lFpQCWtZCRCSeNdfhubuZfaOpbY32kvaofqTX2H5dYhyJiIjESnPJz1vAaU1sa7SXtEs5BSX06ZpKZufUWIciIiIx0txor0taMxCR1pBbUKL+PiIica65GZ5/0mCXE1rp/R13Xx3VqESioLKmlvzCHUwf0zvWoYiISAw11+G5S4NHV2AS8KqZzWiF2ERa1IpNO6ipc63pJSIS55q77fXbxvabWU/gDWBWtIISiYacXZ2dlfyIiMSzZld1b4y7bwUsCrGIRFVuQQnpyYkMycyIdSgiIhJDe5z8mNl0oDgKsYhEVc7GEkb37UJignJ3EZF41lyH508JdXIO1xPYCHw7mkGJtDR3J7eghFMP6h/rUEREJMaam+fn1AbbDmxx951RjEckKjZsK6ekokb9fUREpNkOz5+1ZiAi0VS/rIXm+BERkT3u8yPSHuVsLMEMxvTVshYiIvFOyY/EhdyCEoZkZpCR2tydXhERiQdKfiQu5BSUaDFTEREBlPxIHCitqGbt1jL19xEREUDJj8SBZZ+HOjtrpJeIiICSH4kDucGyFlrTS0REQMmPxIGcjSV075RM365psQ5FRETaAA19kahxd1YU7mDOskLKq2q5+viRmLX+0hK5BSWM69c1JtcWEZG2R8mPtKiK6lreW7mFOcsKmbOskA3byncdO3hQd44d3btV46mprWPZ56VceNjgVr2uiIi0XUp+ZJ9t2FbOnGWFzF1WyPyVm6moriM9OZGpI3pxxbQRHDWyF+fe+x5/m5PPMaOyWrUFZs2WnVTW1Gmkl4iI7KLkR/ZYTW0di9Zt483cUMKTtyk0mmpQz07MmDyIaWN6c+jQnqQlJ+465/JjhvPr2UtZsHorhw3LbLVYl24MdXbWSC8REamn5EciUryzireWFzFnWSFvLS9ie3k1SQnG5CE9+fnJY5k2pjfDszKabNU5d/JA7pyTz9/m5Ldq8pNbUEpyojGid+dWu6aIiLRtSn6kUe5ObkEpc/NCfXcWrS2mzqFX5xS+Nq4P08f05siRveialhxRfWnJiXz/qKHc/OoyFq0t5uBBPaL8CkJyCkoY0bsLKUka2CgiIiFKfmSXsqoa3s0PdVael1dIwfYKAA7crxszp49k+pjejN+vGwkJe9dn54LDBvP3t1Zy19x87v/O5JYMvUm5BSUcPTKrVa4lIiLtg5IfAeDFxRv42T8/oaK6joyURI4amcX/O743x47OoncLzY/TOTWJS44Yym1vLCdnY0nUJx0sKq2kqLRSa3qJiMiXKPkRnlu4nmue+5jJQ3py1XEjmTykZ9RuE118xBD+8fYq7pqXz13nT4zKNeppZmcREWmMOkLEuac/XMs1z33MkSN68cglU5g6oldU+8d065TMRYcP5pVPC1hZtCNq14FQfx9Aw9xFRORLlPzEscff/4yf/fNTjh6ZxT++PYn0lMTdn9QCLj1yKKlJCdw9d2VUr5NbUEL/bml075QS1euIiEj7EtXkx8xONLM8M8s3s+saOZ5qZk8HxxeY2ZCwY9cH+/PM7IRgX5qZfWBmH5vZUjP7bVj5oUEdK4I69Y3XjEfmr+EXLyzhuDG9ue/bh3xpTp5o69U5lfOmDOKFxRtYt7UsatfJ2Vii+X1EROQropb8mFkicBdwEjAOOM/MxjUodilQ7O4jgNuAW4JzxwEzgP2BE4G7g/oqgenufhAwATjRzA4L6roFuM3dRwLFQd3SiPvfXsWvZy/l6+P68PcLDyE1qfUSn3qXHT2MRDPueSs6rT8V1bWs2rxT/X1EROQrotnyMwXId/dV7l4FzALOaFDmDOCR4PlzwHEWmiXvDGCWu1e6+2ogH5jiIfUdRZKDhwfnTA/qIKjzzGi9sPbs3rdWcuPLuZx8YF/uumBizOa/6dctnW8eMoBns9ezqaSixetfvqmU2jpXy4+IiHxFNL/59gPWhW2vD/Y1Wsbda4DtQGZz55pZopktBgqB1919QXDOtqCOpq5FcP5lZpZtZtlFRUX78PLan7vm5nPzq8s47aD+3DHjYJITY9vl64fHDKfWnfv+u6rF685VZ2cREWlCNL/9GpsJzyMs0+S57l7r7hOAAcAUMzsgwmsRnH+fu09y90lZWfEz+d1f31jBn17L48wJ/bntnINIinHiAzAosxNnHNSfJxesZcuOyhatO2djCRkpiQzq2alF6xURkfYvmt+A64GBYdsDgI1NlTGzJKAbsDWSc919GzCPUJ+gzUD3oI6mrhWX3J2//CeP295YztmHDOAv50xoE4lPvR9NG05FTS0Pvru6RevNLShlTL+uez0btYiIdFzR/Bb8EBgZjMJKIdSBeXaDMrOB7wTPzwbmuLsH+2cEo8GGAiOBD8wsy8y6A5hZOnA8sCw4Z25QB0GdL0bxtbUL7s4t/87jzjn5zJg8kD9+czyJbSwZGNG7Cycd0JdH53/G9vLqFqkztC5ZiWZ2FhGRRkUt+Qn638wEXgNygWfcfamZ3WBmpwfFHgAyzSwf+AlwXXDuUuAZIAf4N3CFu9cC/YC5ZvYJoeTqdXf/V1DXz4CfBHVlBnXHLXfnppdzueetlVx42CB+f9aBbbYV5IppIyitrOHR+WtapL71xeWUVtYwrl+3FqlPREQ6lqgub+HurwCvNNj3q7DnFcC3mjj3JuCmBvs+AQ5uovwqQiPM4p6789uXcnh4/houPmIIvz5tHKEBcW3T/v27MX1Mbx58dzXfPXIoGan79mO5dGOos7NafkREpDFtp/OHtIi6OudXLy7l4flr+N6RQ9t84lPvimkjKC6r5skFa/e5rtyCEhIMxvTVSC8REfkqJT8dSF2d8/MXPuWx9z/jB8cM5+enjG0XiQ/AIYN7cMTwTO57exUV1bX7VFdOQQlDemW02nIdIiLSvij56SBq65yf/fMTnvpgHTOnjeBnJ45uN4lPvZnTR1BUWsmz2et2X7gZuQUlmt9HRESapOSnA6itc6559mOeXbieq48fyf98fVS7S3wADh+WycRB3bnnrVVU19btVR3by6tZX1yumZ1FRKRJSn7auZraOq5+ejH/t2gDP/36KK4+vn0mPgBmxo+nj2TDtnKeX7Rhr+pYVj+zs9b0EhGRJij5aceqa+u4ctYiXvp4I9edNIaZ00fGOqR9duzoLPbv35W/z1tJbV2jk3Q3K0fLWoiIyG4o+WmnqmrqmPnkR7zy6ef84pSx/OCY4bEOqUWYGTOnjWD15p28/GnBHp+fW1BCZkYKvbukRiE6ERHpCJT8tEOVNbX86ImFvLZ0E785bRzfO2rY/2/v3sPkqus8j78/fcn9HhIgN5JwDyAhhIALglxW0XFBVNaw6qLiAyIoOMPswDjrg86wCyg6z7OiLgIzLKKIwoyRZRZQg+iM6c7FBJI0gZAKkAtJSIV0LuTS3d/945wwRdvd6e6cU9VtfV7PU0+fOnXOt35V3afrU+f8zvlVukmZev9JR3DM+GHc/evVtPVw78/Kjc2ceOSIfnvoz8zM8ufw08/s2d/K5x9czC+bNvN3Hz6ZT589rdJNylxNjbju/KNZtWkHv2za1O319re28eKmne7vY2ZmXXL46UdaWtu4+sHFPPPiFm7/yCl88qyjKt2k3Pynd01gypgh3D1/NcnQbQe3Zssu9rW0+crOZmbWJYeffmTRK9t49sUt/Pc/m8HcOVMq3Zxc1dXWcO17j2bZuu389qU3urVO09udnT2ml5mZdc7hpx9pWFNEgo/OmlTpppTFR2ZN5IgRg/jO/NXdWn7lxmYG1NYwfdzQnFtmZmb9mcNPP9K4dsPypDsAABgSSURBVCsnHDGCkUPqK92UshhYV8s1502nsVCksVA86PJNG5s57ohh1Nf6z9rMzDrnT4l+Yl9LG4tf2caZ08ZUuillNfeMKYwdOuCge38igpUbmjnRg5mamdlBOPz0E8+v386e/W2cNb26ws/gAbV87j3TefbFLSx77c1Ol9uyYy9bd+3zmV5mZnZQDj/9RENhKwBnTK2u8APwybOmMGJQHXd3sfdnRdrZ2WN6mZnZwTj89BMNa4ocO34YY4dV35WLhw+q5zNnT+OplZt44fXmDpdpcvgxM7NucvjpB1pak/4+c6qsv0+pz5w9laEDavnu/Jc7fHzlhmYmjhrMyMHV0RnczMx6z+GnH1i5sZmde1s4c/rYSjelYkYNGcAn330Ujz+3gcIbu/7o8aaNze7vY2Zm3eLw0w80rElO8662M73a+9w506mvreF7z7yz789b+1opvLHLh7zMzKxbHH76gYZCkaljh3D4iEGVbkpFjRs+kCvmTOGxJetZt2332/NXbdpBW8AMhx8zM+sGh58+rq0tWLi2yJnTqveQV6mrz52OBPc8u+bteSs3HBjWwuHHzMwOzuGnj1u1aQfb39rPmVV2fZ/OTBg1mI/OmsTDC19jc/MeIOnvM3xgHZNGD65w68zMrD9w+OnjGtYk1/ep5jO92vv8eUfT0trGvb8rAEmH8BOOHE5NjSrcMjMz6w8cfvq4hkKRiaMGM2n0kEo3pc+YethQLjl1Aj9c8Apbd+7lhY3N7uxsZmbd5vDTh0UEjYVi1Z/l1ZEvnH8Mu/e18rVfrGTXvlb39zEzs25z+OnDXt6yk6279rm/TweOO3w4F590BPOWbQB8ZWczM+s+h58+bMHb1/fxmV4due78YwCoERx/xPAKt8bMzPqLuko3wDrXWCgyfvhAjhrr/j4dOWXSSC468XC27NjDoPraSjfHzMz6CYefPioiaChs5czpY5F8FlNnvvNfTqO1LSrdDDMz60ccfvqoV4u72dS8152dD8J7fMzMrKfc56eP8nheZmZm+XD46aMWFLYyZugAjhk/rNJNMTMz+5Pi8NNHNRaKzJk6xv19zMzMMubw0wetf/Mt1m17y9f3MTMzy4HDTx90YDwvX9/HzMwsew4/fVBjociIQXW+cJ+ZmVkOHH76oIZCkTnTxlDrUcrNzMwyl2v4kXSxpFWSVku6uYPHB0r6Sfp4g6SpJY/dks5fJen96bzJkuZLapK0QtINJcvfKmm9pKXp7YN5vra8bG7eQ+GNXT7kZWZmlpPcLnIoqRa4G/iPwDpgoaR5EbGyZLGrgG0RcYykucAdwMclzQDmAicBE4BfSjoOaAH+IiKWSBoOLJb0dEnNb0fEN/N6TeXQUEiu7zPH1/cxMzPLRZ57fuYAqyNiTUTsAx4GLm23zKXAA+n0z4ALlZzbfSnwcETsjYgCsBqYExEbI2IJQETsAJqAiTm+hrJrKGxl6IBaTprgUcrNzMzykGf4mQi8VnJ/HX8cVN5eJiJagO3A2O6smx4iOw1oKJl9vaTnJN0vaXRHjZJ0taRFkhZt2bKlp68pd42FIqdPHUNdrbtjmZmZ5SHPT9iOeuu2H4Gys2W6XFfSMOBR4MaIaE5nfw84GpgJbATu6qhREXFPRMyOiNnjxo3r+hWUWXHXPl7ctNNDWpiZmeUoz/CzDphccn8SsKGzZSTVASOBYlfrSqonCT4PRcRjBxaIiE0R0RoRbcAPSA679SuNheT6Pmf54oZmZma5yTP8LASOlTRN0gCSDszz2i0zD7gynf4Y8OuIiHT+3PRssGnAsUBj2h/oPqApIr5VWkjSkSV3LwOWZ/6KctZQKDKovoZTJo6qdFPMzMz+ZOV2tldEtEi6HngSqAXuj4gVkr4OLIqIeSRB5kFJq0n2+MxN110h6RFgJckZXtdFRKukc4BPAc9LWpo+1V9HxBPAnZJmkhweWwtck9dry0vDmiKzpoxmQJ37+5iZmeUlt/ADkIaSJ9rN+2rJ9B7g8k7WvQ24rd2839FxfyAi4lOH2t5K2v7Wfppeb+bGC4+rdFPMzMz+pHkXQx+xaG2RCF/fx8zMLG8OP31EQ6HIgNoaTpvi/j5mZmZ5cvjpIxoKRU6dPJJB9bWVboqZmdmfNIefPmDn3haWr9/u8bzMzMzKwOGnD1j8yjZa24IzfX0fMzOz3Dn89AGNha3U1ohZUzockcPMzMwy5PDTBzSsKXLKxJEMHZjrlQfMzMwMh5+K27O/lWXr3vQhLzMzszJx+KmwJa9uY39reDBTMzOzMnH4qbCGNUUkmD3V4cfMzKwcHH4qrLFQZMaRIxgxqL7STTEzM6sKDj8VtLellSWvbvP1fczMzMrI4aeCnlu3nb0tbe7sbGZmVkYOPxXUWCgCcIb7+5iZmZWNw08FLVizleMPH86YoQMq3RQzM7Oq4fBTIS2tbSx+ZZsPeZmZmZWZw0+FLN/QzO59rczx9X3MzMzKyuGnQhrWbAVw+DEzMyszh58KaSwUmX7YUMYPH1TpppiZmVUVh58KaG0LGtcW3d/HzMysAhx+KqBpYzM79rT44oZmZmYV4PBTAQeu7+P+PmZmZuXn8FMBDYWtTB4zmAmjBle6KWZmZlXH4afMIoLGQtGHvMzMzCrE4afMXtq8k2279/uQl5mZWYU4/JTZgev7nOU9P2ZmZhXh8FNmDYUiR4wYxOQx7u9jZmZWCQ4/ZRQRNBSS6/tIqnRzzMzMqpLDTxkV3tjFlh173dnZzMysghx+ysjX9zEzM6s8h58yaigUOWzYQI4eN7TSTTEzM6taDj9llFzfx/19zMzMKsnhp0xeK+5m/Ztv+ZCXmZlZhTn8lElD2t/HI7mbmZlVlsNPmTQWtjJqSD3HjR9e6aaYmZlVNYefMmkoFDlj6hhqatzfx8zMrJIcfsrg9e17eGXrbs50fx8zM7OKc/gpg4ZCMp6XL25oZmZWebmGH0kXS1olabWkmzt4fKCkn6SPN0iaWvLYLen8VZLen86bLGm+pCZJKyTdULL8GElPS3op/Tk6z9fWEw2FIsMH1jFjwohKN8XMzKzq5RZ+JNUCdwMfAGYAV0ia0W6xq4BtEXEM8G3gjnTdGcBc4CTgYuC7ab0W4C8i4kTgLOC6kpo3A7+KiGOBX6X3+4TGQpHZU0dT6/4+ZmZmFZfnnp85wOqIWBMR+4CHgUvbLXMp8EA6/TPgQiVXALwUeDgi9kZEAVgNzImIjRGxBCAidgBNwMQOaj0AfDin19Ujb+zcy+rNO5njQ15mZmZ9Qp7hZyLwWsn9dfx7UPmjZSKiBdgOjO3OuukhstOAhnTW4RGxMa21ERjfUaMkXS1pkaRFW7Zs6fGL6qlGX9/HzMysT8kz/HR0jCe6uUyX60oaBjwK3BgRzT1pVETcExGzI2L2uHHjerJqrzQWigyur+WUiSNzfy4zMzM7uDzDzzpgcsn9ScCGzpaRVAeMBIpdrSupniT4PBQRj5Uss0nSkekyRwKbM3slh2DBmq2cftRo6mt9Yp2ZmVlfkOcn8kLgWEnTJA0g6cA8r90y84Ar0+mPAb+OiEjnz03PBpsGHAs0pv2B7gOaIuJbXdS6Evh55q+oh97cvY9Vm3b4+j5mZmZ9SF1ehSOiRdL1wJNALXB/RKyQ9HVgUUTMIwkyD0paTbLHZ2667gpJjwArSc7wui4iWiWdA3wKeF7S0vSp/joingBuBx6RdBXwKnB5Xq+tuxau3UYEHszUzMysD8kt/ACkoeSJdvO+WjK9h05CSkTcBtzWbt7v6Lg/EBGxFbjwEJucqYY1WxlQV8Opk0dVuilmZmaWckeUHDWuLXLa5FEMqq+tdFPMzMws5fCTkx179rN8/Xb39zEzM+tjHH5ysuiVbbQFnDndFzc0MzPrSxx+ctJYKFJXI06b4v4+ZmZmfYnDT04a1mzlXZNGMmRArn3KzczMrIccfnKwe18Lz63b7kNeZmZmfZDDTw7+8OqbtLSFr+9jZmbWBzn85KBhzVZqBLOPGl3pppiZmVk7Dj85aCgUOXniSIYPqq90U8zMzKwdh5+M7dnfyh9ee5M5U33Iy8zMrC/yqUgZq6+t4afXvJsRg73Xx8zMrC9y+MlYbY08lpeZmVkf5sNeZmZmVlUcfszMzKyqOPyYmZlZVXH4MTMzs6ri8GNmZmZVxeHHzMzMqorDj5mZmVUVhx8zMzOrKg4/ZmZmVlUcfszMzKyqOPyYmZlZVXH4MTMzs6ri8GNmZmZVxeHHzMzMqorDj5mZmVUVRUSl21AxkrYAr+RU/jDgjX5Wuz+22bXLW7s/ttm1y1u7P7bZtctXN+/aR0XEuIMtVNXhJ0+SFkXE7P5Uuz+22bXLW7s/ttm1y1u7P7bZtctXN+/a3eXDXmZmZlZVHH7MzMysqjj85Oeefli7P7bZtctbuz+22bXLW7s/ttm1y1c379rd4j4/ZmZmVlW858fMzMyqisOPmZmZVRWHnwxJmixpvqQmSSsk3ZBh7UGSGiUtS2t/LavaJc9RK+kPkh7PuO5aSc9LWippUca1R0n6maQX0vf93RnVPT5t74Fbs6QbM6r95fR3uFzSjyUNyqJuWvuGtO6KQ22vpPslbZa0vGTeGElPS3op/Tk6w9qXp+1uk9Tr02A7qf2N9G/kOUn/JGlUhrX/Nq27VNJTkiZkVbvksZskhaTDMmrzrZLWl/x9fzDLNkv6oqRV6e/zzqxqS/pJSZvXSlqaYe2ZkhYc+D8laU6GtU+V9Pv0/+AvJI3oRd0OP1+y2Ca7qH3I22QXtTPZJnstInzL6AYcCcxKp4cDLwIzMqotYFg6XQ80AGdl3P4/B34EPJ5x3bXAYTm95w8An0unBwCjcniOWuB1kotnHWqtiUABGJzefwT4dEbtPBlYDgwB6oBfAsceQr1zgVnA8pJ5dwI3p9M3A3dkWPtE4HjgGWB2xu1+H1CXTt+RcbtHlEx/Cfh+VrXT+ZOBJ0kuyNrj7aiTNt8K3JTB31xHtc9P//YGpvfHZ/l+lDx+F/DVDNv9FPCBdPqDwDMZ1l4InJdOfxb4217U7fDzJYttsovah7xNdlE7k22ytzfv+clQRGyMiCXp9A6gieTDLovaERE707v16S2z3uqSJgF/BtybVc28pd+ezgXuA4iIfRHxZg5PdSHwckRkdTXwOmCwpDqSoLIho7onAgsiYndEtAC/AS7rbbGIeBYotpt9KUngJP354axqR0RTRKzqTb1u1H4qfU8AFgCTMqzdXHJ3KL3cLjt5vwG+Dfy3HOoesk5qXwvcHhF702U2Z1gbAEkC/jPw4wxrB3Bgj8xIerlddlL7eODZdPpp4KO9qNvZ58shb5Od1c5im+yidibbZG85/ORE0lTgNJI9NFnVrE13824Gno6IzGoDf0/yD7Ytw5oHBPCUpMWSrs6w7nRgC/APSg7X3StpaIb1D5hLL//JthcR64FvAq8CG4HtEfFUFrVJ9vqcK2mspCEk314nZ1T7gMMjYiMk/9SA8RnXL4fPAv+SZUFJt0l6DfgE8NUM614CrI+IZVnVLHF9esjh/t4evuzEccB7JDVI+o2kMzKsfcB7gE0R8VKGNW8EvpH+Hr8J3JJh7eXAJen05Rzidtnu8yXTbTKPz65u1M58mzwYh58cSBoGPArc2O5b4SGJiNaImEmSkOdIOjmLupI+BGyOiMVZ1OvA2RExC/gAcJ2kczOqW0eye/l7EXEasItkt29mJA0g+af104zqjSb5pjYNmAAMlfTJLGpHRBPJ7uOngf8HLANaulypykj6Csl78lCWdSPiKxExOa17fRY10wD7FTIMUyW+BxwNzCQJ4XdlWLsOGA2cBfwl8Ei6pyZLV5DRF5IS1wJfTn+PXybdo5yRz5L871tMcuhnX28L5fX5UqnaeW2TB+PwkzFJ9SS/4Ici4rE8niM9tPMMcHFGJc8GLpG0FngYuEDSDzOqTURsSH9uBv4J6FVHwg6sA9aV7AH7GUkYytIHgCURsSmjehcBhYjYEhH7gceA/5BRbSLivoiYFRHnkux6z/KbMcAmSUcCpD97dUijEiRdCXwI+ESkHQ1y8CN6cUijE0eThORl6bY5CVgi6YhDLRwRm9IvU23AD8hum4Rku3wsPVTfSLI3uccdtTuTHi7+CPCTrGqmriTZHiH5spPZexIRL0TE+yLidJLQ9nJv6nTy+ZLJNpnnZ1dntcu0TXbI4SdD6beb+4CmiPhWxrXHHegNL2kwyYfoC1nUjohbImJSREwlOcTz64jIZG+EpKGShh+YJunk9kdns/RGRLwOvCbp+HTWhcDKLGqXyPob5qvAWZKGpH8vF5IcA8+EpPHpzykkHxBZfzueR/IhQfrz5xnXz4Wki4G/Ai6JiN0Z1z625O4lZLddPh8R4yNiarptriPpOPr6odY+8GGZuoyMtsnUPwMXpM9zHMmJCFmO4H0R8EJErMuwJiR9fM5Lpy8gwy8OJdtlDfA3wPd7UaOzz5dD3iZz/uzqsHae22S3HGqPad/e0av9HJL+Lc8BS9PbBzOq/S7gD2nt5fTyLIduPM97yfBsL5J+OcvS2wrgKxm3dyawKH1f/hkYnWHtIcBWYGTGbf4ayQfkcuBB0rNiMqr9W5IAuAy48BBr/ZjkkMh+kg/eq4CxwK9IPhh+BYzJsPZl6fReYBPwZIa1VwOvlWyXvT0jq6Paj6a/y+eAX5B05sykdrvH19K7s706avODwPNpm+cBR2b4fgwAfpi+J0uAC7J8P4B/BD6fw9/2OcDidNtpAE7PsPYNJGc5vQjcTjq6Qg/rdvj5ksU22UXtQ94mu6idyTbZ25uHtzAzM7Oq4sNeZmZmVlUcfszMzKyqOPyYmZlZVXH4MTMzs6ri8GNmZmZVxeHHzA5KyYjid5Xcv0nSrRnV/kdJH8ui1kGe5/J0ZOn5HTz2jXTE6W/0ou5M9XJUdDOrDIcfM+uOvcBHJGV2pd4sSKrtweJXAV+IiPM7eOwakgsI/mUvmjGT5Lol3aaE//+aVYg3PjPrjhbgHpIxj96h/Z4bSTvTn+9NB7Z8RNKLkm6X9AlJjZKel3R0SZmLJP02Xe5D6fq16R6ZhekAnNeU1J0v6UckF+pr354r0vrLJd2RzvsqycXWvt9+746keSSjsTdI+nh6NfVH0+ddKOnsdLk5kv5NySC6/ybp+HTst68DH5e0NF3/Vkk3ldRfLmlqemuS9F2Si/9NlvQ+Sb+XtETST9Pxj0jfq5Xp6/5mT39ZZta1uko3wMz6jbuB5yTd2YN1TgVOJBlnbA1wb0TMkXQD8EWSkbQBppIMLXA0MF/SMcB/JRn1/gxJA4F/lfRUuvwc4OSIKJQ+maQJJIO7ng5sA56S9OGI+LqkC4CbImJR6ToRcYmknZEMGkwaqr4dEb9Lhwl5Mn0NLwDnRkSLpIuA/xERH02D1eyIuD5d/9Yu3o/jgc9ExBfSvWh/A1wUEbsk/RXw55K+Q3Jl3RMiIg4Ma2Nm2XH4MbNuiYhmSf8H+BLwVjdXWxgRGwEkvQwcCC/PA6WHnx6JZJDNlyStAU4gGQfuXSV7lUYCx5KMiN3YPvikzgCeiYgt6XM+BJxLMvRJd10EzNC/D0Q+Ih2fbiTwQDqWVwD1Pah5wCsRsSCdPguYQRLqIBkW4vdAM7AHuFfS/wUe78XzmFkXHH7MrCf+nuSQzT+UzGshPYSeDmI4oOSxvSXTbSX323jn/5/24+wEIOCLEfFk6QOS3gvs6qR96mR+T9QA746IdwQ8Sf8LmB8Rl0maCjzTyfpvvx+pQSXTpe0W8HREXNG+gKQ5JIPezgWuJx0o1Myy4T4/ZtZtEVEEHiHpPHzAWpLDTACX0rs9IpdLqkn7AU0HVpEcbrpWUj0kI4RLGnqQOg3AeZIOSztDXwH8podteYokcJA+78x0ciSwPp3+dMnyO4DhJffXArPSdWcB0zp5ngXA2ekhPiQNSV/jMJLBdJ8gOSw4s5P1zayXHH7MrKfuAkrP+voBSeBoBM6k870yXVlFElL+hWTE7j3AvSQj1C+RtBz43xxkb3V6iO0WYD7J6NxLIuLnPWzLl4DZaWfjlcDn0/l3Av9T0r8CpWeZzSc5TLZU0sdJRnkfI2kpcC3JSN4dtXULSYj6saTnSMLQCSRB6vF03m/ooJO5mR0aj+puZmZmVcV7fszMzKyqOPyYmZlZVXH4MTMzs6ri8GNmZmZVxeHHzMzMqorDj5mZmVUVhx8zMzOrKv8fHjBdjUz2NmwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 648x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(9,7))\n",
+    "plt.plot(nfeatures, beta)\n",
+    "plt.xlabel(\"Number of features\")\n",
+    "plt.ylabel(\"UPM Coefficient\")\n",
+    "plt.xticks(nfeatures)\n",
+    "plt.title(\"UPM Coefficient vs Number of Features\")\n",
+    "plt.savefig(\"upm_vs_nfeatures_all.png\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAG5CAYAAACtNG+EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xd83WXd//HXJ7tJTtKR1bSlM2mbdNGWISICIpsWEbEoeiMiyu9miYqI3twCDgQX3KAIKgJCyxIBGWXv0ZbSvRfdTdKRZjT7+v1xTtpDmnGSnJOz3s/HI4+c8T3X+ZzTpOeda33NOYeIiIhIJEsIdwEiIiIiXVFgERERkYinwCIiIiIRT4FFREREIp4Ci4iIiEQ8BRYRERGJeAosIjHEzC42s3fCXUekMLOfm9k/w/j8vzCzCjPbGa4aRGKFAovEFTNzZjamzW0HP9TM7EQzazGzajOrMrPVZvYt330jfI9f2ObxOWbWYGab+uyFRCkze8PM6sxsmN9tp8Tie+d7jT8ASpxzBe3c7/+z1vr1bBCe9x9m9ovetiMSaRRYRA633TmXCWQBPwbuM7MSv/szzGyC3/WvARv7ssAoVwP8T7iL6C4zS+rmQ4YDu51zZZ0cs905l+n3dU4vSgyKHrxOkT6hwCLSAef1b2Av4B9YHgL+y+/6N4EHO2vL1zNzlZlt8A0R3G5m7f7+mdk9ZvbbNrc9bWbX+i5fb2brfT1AK8zsSx2009ojlOR32xtmdqnf9UvMbKWZ7TWzuWY2vIO2XjSzK9rcttjMzjOvP5hZmZlVmtmSNoGurTuBC9v2dPm1+6leMP8eA1+vxFYzu873fDvM7FwzO9PM1pjZHjO7oU2TaWb2qO/9Wmhmk/3aLjSzJ82s3Mw2mtlVfvf93MyeMLN/mtl+4OJ2as02swd9j//EzH5mZglmdgrwMlDo6zn5RyfvR3vvQYLfv/NuM3vMzAb63f+4me30vd9vmVmp7/bLgK8D1/n32AT4nv7YvENX9/tuP9vMFpnZPjN7z8wm+T3+x2a2zQ71Qn6hO69PpCcUWEQ64PvQ+BLQH1jqd9c/gVlmlmhm4wEP8GEATX4JmA5MBWYCl3Rw3CPAV83MfHUMAE4F5vjuXw98DsgGbgL+aWaDu/PafO2eC9wAnAfkAm8Dszup6UK/x5bg7UF4zlfbCUAx3vfqq8DuTp56G3Af8PPu1uxTAKQBQ4AbfW1dBEzD+77caGaj/I6fCTwODPS9jn+bWbIvMD4LLPa19QXgGjM7rc1jn/C9rofbqeX/8P47jAI+jze8fss59wpwBod6UC7u5mu8CjjX12Yh3tB8t9/9LwBFQB6wsLU259y9vsu3dbPHpgDv+zMcuMzMpgJ/B74LDAL+AjxjZqlmNha4AjjKOecBTgM2dfP1iXSbAovI4QrNbB9QAfwv8A3n3Gq/+7cCq4FT8Pa0dNq74uc3zrk9zrnNwB/xCwBtvA04vB++AOcD7zvntgM45x53zm13zrU45x4F1gJHB/7yDvou8Gvn3ErnXBPwK2BKB70sT7W57+vAv5xz9UAj3tA2DjBfezu6eO5fA+e09gx0UyPwS+dcI94QlwPc4Zyrcs4tB5YDk/yO/8g594Tv+N/jDTvHAkcBuc65m51zDc65DXjDzyy/x77vnPu3770+4F+EmSXiDWc/8T33JuB3wDe68VoKfT0YrV8X+G7/LvBT59xW33v8c+D81t4y59zffc/Zet9kM8vuxvO21QL8r3Ou3vc6vwP8xTn3oXOu2Tn3AFCP931rBlKBEjNLds5tcs6t78VziwREgUXiTTOQ3Oa2ZLwfgq22O+f6O+cGOuemOOfmcLgH8Q4RXIi3xyUQW/wuf4L3L2fMbLkdmnT5Oec9I+kcDgWar+H3172ZfdOvq34fMAHvh3Z3DQfu8GtnD2B4exs+xTlXhbc3pfXDfBaH/qp/DbgLbw/ALjO718yyOnti51y57zE396Du3c65Zt/l1hCxy+/+A0Cm3/WD77tzrgVv4CzE+/o/FRjw9jjlt/fYduQAKXj/LVt9QjvvXydaf9Zavx7z3T4ceMqvrpV4f3bzfT17t/qGi/ZzqHejJz8Drcqdc3V+14cDP2jz3gwDCp1z64Br8AalMjObY2aFvXhukYAosEi82QyMaHPbSD79oROIJ4GzgA3OuUAfO8zv8hFAa49Jqd+ky7d998/G+xf1cOAY3/Phu34f3i75Qc65/sAyvEGjrRrf93S/2/xXq2wBvtvmA7Ofc+69DuqfjXfuyWeAfsDrrXc45+50zk0DSvEODf2o03fC63bgJLxDOf5qO6m5J/xXJCUAQ/G+91uAjW1ev8c5d6bfYzs7nX0F3qDr3yN1BN4hr97aApzRprY059w2vAF2Jt4evmwO/Ty3/gy0V3NX72nbx2zB24vl//zpzrnZAM65R5xzx+N97Q74Tc9epkjgFFgk3jwK/MzMhvpNjjwH7zyFgDnnaoCTgUu7OtbPj8xsgHmXu17tq6Wj9j8GyoG/AnOdc/t8d2Xg/YAoBzDvkut2J7j6ejG2ARf5/iq/BBjtd8g9wE/8Jmxmm9lXOqn/ebwfUDcDj/p6KzCzo8zsGDNLxhuS6vD2BnTK95p+B1zX5q5FwNd8NZ+Odx5Hb0wz7+TgJLw9A/XAB8A8YL9vAmk/3/NNMLOjAmnU18vzGPBLM/P4wuS1BN7j1pl7fO0OBzCzXDOb6bvP43sNu/GGkF+1eewuvHNq/HX3Pb0P+J7v39XMLMPMzvK9zrFmdrKZpeL9tz5AAP/eIr2lwCLx5mbgPeAdvBMZbwO+7pxb1t2GnHMLujl2/zTwEd4Pj+eAv3Vx/Gy8f0U/4vecK/B+yL+P94NpIvBuJ218B29vx268vR8He0+cc0/h/ct4jm9oYRneiaLt8s2X+FfbmvAu/74P7/v5ie+5fntYA+27g8M/7K7GGyL34Z0r8+8A2+rI03jnmuzFO7/kPOdcoy9wnANMwbssvQJvQOzOXJAr8Ya0DXh/ph7BO1m1t+4AngFeMrMqvAHrGN99D+J9n7cBK3z3+fsb3vkl+8ys9b3r1nvqnFuA92fnLrzv2zoOrZJKBW7F+37txDvxt+3KLJGgM+9wuYiEkpk5oMg3/i8iIt2kHhYRERGJeAosIiIiEvE0JCQiIiIRTz0sIiIiEvGi7iRXOTk5bsSIEeEuQ0RERILgo48+qnDO5XZ1XNQFlhEjRrBgwYJwlyEiIiJBYGYBbb6pISERERGJeAosIiIiEvEUWERERCTiKbCIiIhIxFNgERERkYinwCIiIiIRT4FFREREIp4Ci4iIiEQ8BRYRERGJeAosIiIiEvEUWERERCTiKbCIiIhIxFNgERERkYinwCIiIiIRT4HFZ/u+A3yyuybcZYiIiEg7FFh8zv/ze/z2pTXhLkNERETaocDiU1KYzfLtleEuQ0RERNqhwOJTWpjFxooaauqbwl2KiIiItKHA4lNamIVzsGrn/nCXIiIiIm0osPiUDskGYPl2BRYREZFIo8DiU5idRv/0ZJZvU2ARERGJNAosPmZGaWEWy3do4q2IiEikUWDxU1qYzZqd1TQ2t4S7FBEREfGjwOKntDCLhuYW1u6qDncpIiIi4keBxU9pYRaA9mMRERGJMAosfkbmZNIvOVErhURERCKMAoufxARj3GAPKxRYREREIooCSxulhVms2LGflhYX7lJERETER4GljdLCbKrrm9i8pzbcpYiIiIiPAksbrRNvV+zQsJCIiEikUGBpozjfQ2KCaaWQiIhIBFFgaSMtOZGivEytFBIREYkgCiztKCnMUmARERGJIAos7SgtzKa8qp6yqrpwlyIiIiIosLTr0I636mURERGJBAos7ShpXSmkwCIiIhIRFFjakZWWzBED07VSSEREJEIosHSgVBNvRUREIoYCSwdKBmfxye5a9tc1hrsUERGRuKfA0oHSId55LCvVyyIiIhJ2CiwdKC3MBrRSSEREJBIosHQgz5NKTmaKAouIiEgEUGDpgJlRUpitlUIiIiIRQIGlE6WFWawrq6a+qTncpYiIiMQ1BZZOlBZm0dTiWLOzOtyliIiIxDUFlk4cmnirYSEREZFwUmDpxPCB6WSmJmnirYiISJgpsHQiIcEYP9ijHhYREZEwU2DpQmlhNit3VNHc4sJdioiISNxSYOlCSWEWBxqb2VhRE+5SRERE4pYCSxdKC71b9K/YoXksIiIi4aLA0oWiPA/JiaZ5LCIiImGkwNKFlKQEivM9rNBKIRERkbBRYAlAaWEWy7fvxzlNvBUREQkHBZYAlBZms6emgZ3768JdioiISFxSYAlA68Tb5ds0LCQiIhIOCiwBGD84CzO0462IiEiYKLAEICM1iZGDMrRSSEREJEwUWAJU4pt4KyIiIn0vpIHFzE43s9Vmts7Mru/gmAvMbIWZLTezR0JZT2+UFmazbd8B9tU2hLsUERGRuBOywGJmicDdwBlACXChmZW0OaYI+AnwWedcKXBNqOrprYM73qqXRUREpM+FsoflaGCdc26Dc64BmAPMbHPMd4C7nXN7AZxzZSGsp1dKWlcKKbCIiIj0uVAGliHAFr/rW323+SsGis3sXTP7wMxOb68hM7vMzBaY2YLy8vIQldu5nMxU8rNSNfFWREQkDEIZWKyd29puFZsEFAEnAhcCfzWz/oc9yLl7nXPTnXPTc3Nzg15ooEoLs9XDIiIiEgahDCxbgWF+14cC29s55mnnXKNzbiOwGm+AiUilhVmsL6/mQENzuEsRERGJK6EMLPOBIjMbaWYpwCzgmTbH/Bs4CcDMcvAOEW0IYU29UlqYRYuDVTvVyyIiItKXQhZYnHNNwBXAXGAl8JhzbrmZ3WxmM3yHzQV2m9kK4HXgR8653aGqqbdKC7MBTbwVERHpa0mhbNw59zzwfJvbbvS77IBrfV8Rb+iAfmSlJSmwiIiI9DHtdNsNZkZJYRYrtFJIRESkTymwdFNpYTardlbR1NwS7lJERETihgJLN5UWZlHf1MKGippwlyIiIhI3FFi66dDEWw0LiYiI9BUFlm4anZtBalICy7dp4q2IiEhfUWDppqTEBMYVeLRSSEREpA8psPRASWE2y7dX4l2VLSIiIqGmwNIDpYVZ7K9rYuveA+EuRUREJC4osPRAaWEWoB1vRURE+ooCSw+MK8giwdAGciIiIn1EgaUH+qUkMjo3Uz0sIiIifUSBpYdKC7MUWERERPqIAksPlRZms3N/Hbur68NdioiISMxTYOkhTbwVERHpOwosPVSiwCIiItJnFFh6qH96CkP699M5hURERPqAAksvlBRmsUI9LCIiIiGnwNILpYVZbNxdQ019U7hLERERiWkKLL1QWpiNc7Byh3pZREREQkmBpRe0UkhERKRvKLD0wuDsNAakJ2virYiISIgpsPSCmVFamK0eFhERkRBTYOml0sIs1uyqoqGpJdyliIiIxCwFll4qKcyisdmxrqw63KWIiIjELAWWXiotzAbQPBYREZEQUmDppZE5GfRLTtQ8FhERkRBSYOmlxARj/GCPdrwVEREJIQWWICgtzGbFjv20tLhwlyIiIhKTFFiCoLQwi+r6JjbvqQ13KSIiIjFJgSUIDk281bCQiIhIKCiwBEFxQSZJCaaVQiIiIiGiwBIEqUmJjMnLVA+LiIhIiCiwBIm26BcREQkdBZYgKS3MoqK6nrL9deEuRUREJOYosARJaWEWoIm3IiIioaDAEiQlBwOLJt6KiIgEmwJLkHjSkhk+KF09LCIiIiGgwBJEpYVZCiwiIiIhoMASRKWF2WzeU8v+usZwlyIiIhJTFFiCqGSwdx6LToQoIiISXAosQaSVQoF5etE2LntwQbjLEBGRKJIU7gJiSV5WGjmZqVop1AnnHH98ZS0bK2rYXV3PoMzUcJckIiJRQD0sQVZamKUhoU58sGEPGytqAFizqzrM1YiISLRQYAmy0sIs1pZVU9fYHO5SItLseZtJS/b+2K0tqwpzNSIiEi0UWIKstDCb5hbHWvUeHGZvTQMvLtvJV6cPI7tfMqt3KrCIiEhgFFiCrFQ73nboyYVbaWhu4cJjjqA4P1OhTkREAqbAEmRHDEwnMzVJK4XacM4xe95mjjyiP+MKsijO97B6VxXOuXCXJiIiUUCBJcgSEoySwVnqYWljwSd7WV9ew4VHHwFAcb6HygONlFfVh7kyERGJBgosIVBSmMXKHVU0t6j3oNXsDzfjSU3i7EmDAW9gAVi9S/NYRESkawosIVBamMWBxuaDy3fjXWVtI88t3cHMIwtJT/Fu/VOcnwloabOIiARGgSUESguzAU28bfXUx1upb2o5OBwEMCgzlZzMFNZopZCIiARAgSUEivIzSUlM0AZytE623cLkodkHg1yrojwPa7QXi4iIBECBJQSSExMoLsjUSiFg4eZ9rN5VxSy/3pVWYws8rN1VrZVCIiLSJQWWECkdnM3y7ZVx/2E8Z95mMlISOWdy4WH3FeVnUl3fxPbKujBUJiIi0USBJURKh2Sxt7aRHXH8Yby/rpFnl2xnxpQhZKYefp7Nsb6VQprHIiIiXVFgCZFDO97G77DQ0x9vo66xhQuPHtbu/UWtgUVLm0VEpAsKLCEyriALs/hdKeSc45F5WygtzGLikOx2j8nul0xBVpr2YhERkS4psIRIRmoSI3My4raHZcnWSlbu2M+FRx+BmXV4XFF+pnpYRESkSwosIVRamB23S5tnz9tMv+REZk45fLKtv7H5HtaVVWtXYBER6ZQCSwiVFmaxbd8B9tY0hLuUPlVd38Qzi7dzzuTBeNKSOz22ON9DXWMLW/bU9lF1IiISjRRYQqh14u2KHfHVy/LMou3UNjR/amfbjhQXaOKtiIh0TYElhOJ1i/7Z8zYzrsDDlGH9uzy2KK/1nEIKLCIi0jEFlhAamJHC4Oy0uJp4u2xbJUu3VXY52bZVRmoSQwf000kQRUSkUwosIVYyOCuuAsvseZtJTUrg3COHBPyY4nyPelhERKRTCiwhVlqYxYbyag40NIe7lJCrqW/i6UXbOWvSYLL7dT7Z1l9xvocN5TU0NreEsDoREYlmCiwhVlKYTYuDVTtjv5flP0u2U13fxNcCmGzrrzg/k4bmFj7ZXROiykREJNopsIRY60qh9zfsDnMloTd73haK8jKZNnxAtx5XfHCLfs1jERGR9oU0sJjZ6Wa22szWmdn17dx/sZmVm9ki39eloawnHIYO6Mdxowfx+5fW8PqqsnCXEzIrtu9n0ZZ9zApwsq2/MXmZJBis1kkQRUSkAyELLGaWCNwNnAGUABeaWUk7hz7qnJvi+/prqOoJFzPjnm9MY2yBh8sf/oj5m/aEu6SQmDN/MylJCZzXjcm2rdKSExk+KIO1ZQosIiLSvlD2sBwNrHPObXDONQBzgJkhfL6IlZWWzAOXHE1hdj8u+cf8mNuu/0BDM099vI0zJxQwICOlR20U5WWqh0VERDoUysAyBNjid32r77a2vmxmS8zsCTMb1l5DZnaZmS0wswXl5eWhqDXkcjJTefDbR5OZmsQ3/z6PTRWxM8H0uaU7qKprYlY3J9v6G1vgYdPuWuqbYn81lYiIdF8oA0t7ExnanuHuWWCEc24S8ArwQHsNOefudc5Nd85Nz83NDXKZfWfogHQe+vbRNLe0cNHfPmTX/rpwlxQUs+dtZlROBseMHNjjNoryPTS3ODaUx06QExGR4AllYNkK+PeYDAW2+x/gnNvtnKv3Xb0PmBbCeiLCmDwP//jW0eytaeAbf/uQfbXRfWLENbuq+OiTvQHvbNuRsfk6p5CIiHQslIFlPlBkZiPNLAWYBTzjf4CZDfa7OgNYGcJ6IsbkYf2595vT2VRRy7f+MZ/ahqZwl9Rjs+dtJjnROG9q9yfb+huZk0FSgimwiIhIu0IWWJxzTcAVwFy8QeQx59xyM7vZzGb4DrvKzJab2WLgKuDiUNUTaT47Joc7LzySxVv28d2HPorKuRt1jc38a+E2TistYFBmaq/aSklKYGROhvZiERGRdoV0Hxbn3PPOuWLn3Gjn3C99t93onHvGd/knzrlS59xk59xJzrlVoawn0pw+oYBbz5vE22sruPbRxTS3tJ3iE9leXLaTygON3d7ZtiM6p5CIiHREO92G2QVHDeOGM8fx3NId/Ozfy3AuekLLI/M2M3xQOseOGhSU9orzPWzeUxsX510SEZHuUWCJAJedMJrLTxzN7HmbuX3u6nCXE5B1ZdXM27iHWUcdQUJCzyfb+ivOz8Q5b9siIiL+ksJdgHhdd9pY9tU28qc31jMgPYXvnDAq3CV16tH5m0lKMM6fNjRobRYXHFopNHFodtDaFRGR6KfAEiHMjF+cO4H9Bxr55fMryU5P5oLp7e6jF3b1Tc088dFWTi3NJ9fTu8m2/oYPTCclMUHzWERE5DAKLBEkMcH4/Vcns7+ukeufXEJWWjKnTygId1mHmbt8F3trG5l1VHAm27ZKSkxgdF6mAouIiBxGc1giTGpSIvdcNI3Jw/pz1eyPeW9dRbhLOsyceZsZOqAfx4/JCXrbxfmZWtosIiKHUWCJQBmpSdx/8VGMyEnnOw8uYPGWfeEu6aCNFTW8t343Fx4dvMm2/orzPWzbd4Cqusagty0iItFLgSVC9U9P4aFvH8OAjBQuvn8e68oiY5hkzvzNJCYYXwniZFt/xb4t+tdqpZCIiPhRYIlg+Vlp/PPbx5CYkMA3/jaPbfsOhLWehqYWnvxoK18Yl0deVlpInqP1nEJrNY9FRET8KLBEuBE5GTz07aOprm/iG3/9kIrq+q4fFCKvrNxFRXUDFx4T3Mm2/oYO6Ee/5ERW71QPi4iIHKLAEgXGD87i/ouPYnvlAS6+f17Y5nfMnreZIf37cUJRbsieIyHBKMrPZG2EDIGJiEhkUGCJEtNHDOTPF01j1Y4qLn1gAXWNfbt9/ZY9tby9toILpg8jMQSTbf0V5XlYvVOBRUREDlFgiSInjc3jdxdMZt6mPVzxyMc0Nbf02XPPmb+ZBIMLjgrNZFt/YwsyKauqZ19tQ8ifS0REooMCS5SZOWUIN88o5ZWVu7juySW09MEZnhubW3hswVZOGpvH4Ox+IX++ovzWLfo1j0VERLwUWKLQNz4zgmu/WMy/Fm7jF8+tDHloeW1VGeVV9Vx4dOgm2/obm3/onEIiIiKgrfmj1pUnj2FvbQN/f3cj/1mynZPG5nHSuDyOL8ohMzW4/6yz522mICuNE8eGbrKtv8HZaXhSkxRYRETkoC4/2cwsH/gVUOicO8PMSoDPOOf+FvLqpENmxv+cVcKUYf15acUunl+6g0cXbCElMYFjRg3k5HF5nDwuj+GDMnr1PFv31vLmmnKuPGkMSYl90yFn5l0ppMAiIiKtAvlT/B/A/cBPfdfXAI8CCixhlpBgzJwyhJlThtDY3MKCTXt5bdUuXltVxk3PruCmZ1cwOjfDF17ymT5iAMndDB2PLdgKwAVH9e2Zo4vzPby0YlefPqeIiESuQAJLjnPuMTP7CYBzrsnM+nZNrXQpOTGBz4wexGdGD+KnZ5Xwye4aXltVxmurynjgvU+47+2NeNKSOKE4l5PH5nHi2FwGZaZ22mZTcwuPzd/C54tzGTogvY9eiVdxvoc587dQUV1PThd1iohI7AsksNSY2SDAAZjZsUBlSKuSXhs+KINvfXYk3/rsSKrrm3hnbQWvryrjtdVlPLdkB2YwZVh/Th6bx8nj8ygZnIXZp/dXeWN1OTv31/HzGaV9Xn/rOYXW7KwiZ4wCi4hIvAsksFwLPAOMNrN3gVzg/JBWJUGVmZrE6RMKOH1CAS0tjuXb9/t6X3bxu5fX8LuX11CQlcZJvnkvnx0ziPSUJObM30yuJ5UvjM/r85qLCzIB70qh48bk9Pnzi4hIZOkysDjnFprZ54GxgAGrnXPh2Rteei0hwZg4NJuJQ7O5+pQiyqrqeGN1Oa+vKuOZRduYPW8zKUkJHDtqEO+sLefyE0d3e95LMORmptI/PZnV2otFREQIbJXQN9vcNNXMcM49GKKapA/ledK4YPowLpg+jIamFuZv2sOrK729L6lJicw6qm/2XmnLzCjO9+iszSIiAgQ2JHSU3+U04AvAQkCBJcakJCXw2TE5fHZMDjeeU0Jjc0tYeldaFedn8vSi7TjnDptfIyIi8SWQIaEr/a+bWTbwUMgqkogRzrAC3h1vq+qa2LW/noLstLDWIiIi4dWTT6RaoCjYhYi01XpOodUaFhIRiXuBzGF5Ft+SZrwBpwR4LJRFicChpc1rd1Xx+eK+OS2AiIhEpkDmsPzW73IT8IlzbmuI6hE5aGBGCjmZqazeqR4WEZF4F8gcljf7ohCR9owtyGRNmZY2i4jEuw7nsJhZlZntb+erysz292WREr+K8rxLm1taXNcHi4hIzOqwh8U55+nLQkTaM7bAQ21DM9v2HWDYwL49n5GIiESOQOawAGBmeXj3YQHAObc5JBWJ+CnOP7RFvwKLiEj86nJZs5nNMLO1wEbgTWAT8EKI6xIBDi1tXqMt+kVE4log+7DcAhwLrHHOjcS70+27Ia1KxCcrLZnB2Wms0V4sIiJxLZDA0uic2w0kmFmCc+51YEqI6xI5qDjfo8AiIhLnApnDss/MMoG3gIfNrAzvfiwifaI4P5MPNuymucWRmKBzComIxKNAelhm4t2O//vAi8B64JxQFiXirzjfQ31TC5v31Ia7FBERCZNAAstlQKFzrsk594Bz7k7fEJFIn2jdol873oqIxK9AAksWMNfM3jaz/zaz/FAXJeKvyLe0ea3msYiIxK0uA4tz7ibnXCnw30Ah8KaZvRLyykR80lOSGDawn87aLCISxwLpYWlVBuwEdgN5oSlHpH1j8z2s1V4sIiJxK5CN4y43szeAV4Ec4DvOuUmhLkzEX1G+hw0V1TQ2t4S7FBERCYNAljUPB65xzi0KdTEiHRmb76Gx2bGpoubg7rciIhI/ApnDcn1rWDGzy0JfksjhWifeah6LiEh86s4cFoDvhaQKkS6Mzs0kwXROIRGReNXdwKJtRiUs0pITGTEogzXai0VEJC51N7CcHZIqRAJQnO9hTZkCi4hIPAqRCWOGAAAgAElEQVRkldAgM/s/M1sIPGNmd5jZoD6oTeRTivMz2VRRQ11jc7hLERGRPhZID8scvHuwfBk4HygHHg1lUSLtKS7w0OJgQ3lNuEsREZE+FkhgGeicu8U5t9H39Qugf6gLE2mr9ZxCa7RSSEQk7gQSWF43s1lmluD7ugB4LtSFibQ1YlAGyYmmwCIiEocCCSzfBR4B6n1fc4BrzazKzPaHsjgRfylJCYzMyVBgERGJQ13udOuc07aiEjGK8z0s3rov3GWIiEgf6+6yZpGwKs73sGXPAWobmsJdioiI9CEFFokqrRNvdeZmEZH4osAiUaXYd04hzWMREYkvHc5hMbOBnT3QObcn+OWIdG74oAxSkhIUWERE4kxnk24rgK1A62QB//MIOWBUqIoS6UhigjEmN1MnQRQRiTOdBZb/A04E3gVmA+8451xfFCXSmbEFHj7YsDvcZYiISB/qcA6Lc+5qYArwOPAN4GMzu83MRvZVcSLtKcrPZEdlHfvrGsNdioiI9JFOJ906r9eB64B7gG8Bp/RFYSIdGXtwpZDmsYiIxIsOA4uZZZjZ18zsaeB5IBOY6py7r8+qE2nHoXMKaR6LiEi86GwOSxmwFu/8lXV4J9oeZWZHATjn/hX68kQON6R/P9JTElm9Uz0sIiLxorPA8jjekDLO9+XPAQosEhYJCUZRXiZryxRYRETiRYeBxTl3cR/WIdItxfkeXl9dHu4yRESkj3Q2h+UYM1tsZtVm9r6Zje/LwkQ6U5zvoaK6nj01DeEuRURE+kBnq4TuBn4IDAJ+D/yxTyoSCUBxQevEWw0LiYjEg84CS4Jz7mXnXL1z7nEgt7uNm9npZrbazNaZ2fWdHHe+mTkzm97d55D41HpOIS1tFhGJD51Nuu1vZud1dL2rVUJmloi3l+aLeLf4n29mzzjnVrQ5zgNcBXzY3eIlfhVkpeFJS2K1AouISFzoLLC8CZzTwfVAVgkdDaxzzm0AMLM5wExgRZvjbgFuwzv8JBIQM6M436O9WERE4kRnq4S+1cu2hwBb/K5vBY7xP8DMjgSGOef+Y2YdBhYzuwy4DOCII47oZVkSK4rzPbywbAfOOcys6weIiEjU6jCwmNm1bW5yeM/g/I5zbmMAbbf3CXLw5IlmlgD8Abi4q4acc/cC9wJMnz5dJ2AUwDuPZfa8Rsqr68nzpIW7HBERCaHOJt162nxlAdOBF8xsVgBtbwWG+V0fCmxv0/4E4A0z2wQcCzyjibcSqNZzCq3ZqWEhEZFY19mQ0E3t3W5mA4FXgDldtD0fKPKd3XkbMAv4ml/7lUCOX7tvAD90zi0ItHiJb0X5h5Y2H1+U08XRIiISzTo9W3N7nHN7aH+4p+1xTcAVwFxgJfCYc265md1sZjO6XalIGzmZKQzMSNFeLCIicaCzVULtMrOTgb2BHOucex7vmZ79b7uxg2NP7G4tEt/MvOcUUmAREYl9nU26XYrfJFmfgXjnoXwzlEWJBGpsgYenFm7TSiERkRjXWQ/L2W2uO2C3c64mhPWIdEtRvoeq+iZ2VNZR2L9fuMsREZEQ6WzS7Sd9WYhIT7SuFFq9q0qBRUQkhnV70q1IJNE5hURE4oMCi0S1/ukp5HlSWa29WEREYpoCi0S94nwPa8vUwyIiEssUWCTqFed7WLurmpYWnbVBRCRWKbBI1CvOz+RAYzNb9x4IdykiIhIiCiwS9YoLDq0UEhGR2KTAIlGvKM+7Ukg73oqIxC4FFol6nrRkhvTvp8AiIhLDFFgkJhTlZ7Jml5Y2i4jEKgUWiQlj8z2sL6umqbkl3KWIiEgIKLBITCjK99DQ3MIne2rDXYqIiISAAovEhNZzCq3ZqXksIiKxSIFFYsKYvEzM0DwWEZEYpcAiMaFfSiJHDEzXSiERkRilwCIxoyjPo8AiIhKjFFgkZowtyGRjRQ0NTVopJCISaxRYJGYU53toanFsrKgJdykiIhJkCiwSM4rzdU4hEZFYpcAiMWNUbgaJCcZaBRYRkZijwCIxIzUpkRGD0lmtvVhERGKOAovElElD+zN/0x5t0S8iEmMUWCSmnFZawN7aRt7fsDvcpYiISBApsEhMOXFsLhkpiTy/dEe4SxERkSBSYJGYkpacyBfG5/Pisp0aFhIRiSEKLBJzzpw4WMNCIiIxRoFFYo6GhUREYo8Ci8QcDQuJiMQeBRaJSRoWEhGJLQosEpM0LCQiElsUWCQmaVhIRCS2KLBIzNKwkIhI7FBgkZilYSERkdihwCIxS8NCIiKxQ4FFYpqGhUREYoMCi8Q0DQuJiMQGBRaJaRoWEhGJDQosEvPOmqRhIRGRaKfAIjHv88UaFhIRiXYKLBLz/IeFGjUsJCISlRRYJC60Dgt9oGEhEZGopMAicUHDQiIi0U2BReKChoVERKKbAovEDQ0LiYhELwUWiRsaFhIRiV4KLBI3NCwkIhK9FFgkrmhYSEQkOimwSFzRsJCISHRSYJG4kpacyCklGhYSEYk2CiwSd86cqGEhEZFoo8AicUfDQiIi0UeBReKOhoVERKKPAovEJQ0LiYhEFwUWiUsaFhIRiS4KLBKXNCwkIhJdFFgkbmlYSEQkeiiwSNxqHRZ6bomGhUREIp0Ci8St1mGhucs1LCQiEukUWCSuaVhIRCQ6KLBIXNOwkIhIdFBgkbimYaHecc6FuwQRiRMKLBL3NCzUfbUNTfzkX0uZesvLzF2+M9zliEgcUGCRuKdhoe5ZvGUfZ935DnPmb8aTlsx3H/qI37+8hpYW9baISOgosEjc07BQYJpbHHe9tpYv//k96hqbefjSY3jp+yfwlWlDufPVtVz20AL21zWGu0wRiVEKLCJoWKgrW/bUMuve9/ntS2s4bUIBL159AseNziEtOZHbzp/EzTNLeWN1Oefe/S7ryqrDXa6IxCAFFhE0LNQR5xxPfbyVM+94m5U7qvj9BZO568IjyU5PPniMmfHNz4zg4UuPobK2kXPvfpdXVuwKY9UiEotCGljM7HQzW21m68zs+nbu/56ZLTWzRWb2jpmVhLIekY5oWOhwlbWNXDn7Y77/6GLGFnh44erPcd7UoZhZu8cfM2oQz155PCNzMrj0wQXc+epazWsRkaAJWWAxs0TgbuAMoAS4sJ1A8ohzbqJzbgpwG/D7UNUj0hUNCx3y/vrdnHHHW7y4bCc/PLWYOZcdy7CB6V0+rrB/Px7/3mc478gh/P7lNXzvnx9RXd/UBxWLSKwLZQ/L0cA659wG51wDMAeY6X+Ac26/39UMQH+OSdhoWAgamlr49Qsr+dpfPyA1OZEnLz+OK04uIikx8P8q0pIT+d0Fk7nx7BJeXVXGl+5+l40VNSGsWkTiQSgDyxBgi9/1rb7bPsXM/tvM1uPtYbmqvYbM7DIzW2BmC8rLy0NSrEi8DwutK6vi3Lvf5S9vbmDWUcP4z5XHM3lY/x61ZWZccvxIHvr20VRU1zPjrnd4fVVZkCsWkXgSysDS3kD3YT0ozrm7nXOjgR8DP2uvIefcvc656c656bm5uUEuU+SQeBwWcs7x4PubOOvOd9hReYB7vzGNX583iYzUpF63fdzoHJ654niGDUjnkgfmc/fr67Q7roj0SCgDy1ZgmN/1ocD2To6fA5wbwnpEuhRvw0LlVfVc8o/53Pj0co4dNYi515zAqaUFQX2OYQPTefLy45gxuZDb567m/z28kBrNaxGRbgplYJkPFJnZSDNLAWYBz/gfYGZFflfPAtaGsB6RLsXTsNArK3Zx+h/f4r31u7lpRin/+NZR5GWlheS5+qUk8sevTuGnZ45n7vKdnPen9/hkt+a1iEjgQhZYnHNNwBXAXGAl8JhzbrmZ3WxmM3yHXWFmy81sEXAt8F+hqkckUK3DQu+v75thoabmFp5ZvJ3nl+5g1c791DU2h/T5ahuauOGppVz64ALystJ49srj+a/jRnS4XDlYzIzvnDCKBy45ml1Vdcy4613eXKM5aSISGIu28eTp06e7BQsWhLsMiWF1jc1Mu+VlzplcyK1fnhTS51pXVsUPHlvM4q2VB28zg2ED0hmdm8Go3ExG52YevJyTmdKrYLF0ayVXz/mYjbtr+M7nRvGDU4tJTUoMxkvpls27a7nsoQWs2VXFdaeP47snjAp5YBKRyGRmHznnpnd1XO9n1YnEGP9hoVvOnUByN5b0Bqq5xfHXtzfwu5fXkJGSyB2zpjA6N5MNFTWsL6tmfXk1G8preH/DbuoaDw1NZaUlMTovk1E5mYzOyzgYZo4YmEFKUsd1Nrc47nlzPX94eQ05mak8/O1jOG5MTtBfV6COGJTOv/7fcfzoiSXc+sIqlm2r5LbzJ5Geov+SRKR9+t9BpB1nTRzM04u28/763ZxQHNyVaevLq/nR44tZuHkfp5bk88svTSTXkwrAhCHZnzq2pcWxvfIAG8prWF9+KMi8s66cJxduPXhcYoIxfGC6r0fGF2TyMhiVk0lNQxPXPrqYeZv2cNakwfzy3An0T08J6mvqifSUJO668EgmFGZz29xVrCur5r5vTg9ogzoRiT8aEhJpR11jM9N/8QpnTxoctGGhlhbH39/dyO1zV5OWnMhNM0qZOaWwx0MhVXWNbCivYUNFNevLag6GmY0VNTT4TRhOMG84uGlGKedNHRKRQy9vrC7jqtkfk5Bg3HXhVI4vCl/vj4j0rUCHhBRYRDpw9ZyPeWtNOfN+ekqvh4U2VdRw3RNLmLdpD18Yl8evzptIfohW5DS3OLburT3YK1NeXc9FxwyP+J6LTRU1XPbQAtaVVXPDmeP59vEjIzJciUhwKbCI9NJLy3dy2UMf8eAlR/d4WKilxfHQB59w6wurSEo0/vecUr4cob0ckaC6vokfPraYF5fv5LjRgxhXkEV+VioF2WnkZ6VRkOX93i+l7ycKi0hoaNKtSC+dUJxLZmoSzy/d0aPAsmVPLT96YjEfbNjD54tzufXLExmc3S8ElcaOzNQk/nzRVO55cwOPL9jCoi37qG04fJl3VlrSwRBzMMhke797Q00qgzJTSUxQMBSJFQosIh1IS07kC+Pzur1ayDnHwx9u5lfPryTBjN98eSIXTB+mXpUAmRmXnziay08cjXOO6vomdu2vY2dlPTv317HL97Wz0vt9za4qyqvqaWnTWZyYYOR5Un2hJvVToea40TkUZIdmSE5EQkOBRaQT3V0ttHVvLdc/uZR31lVw/JgcfnP+JIb0V69KT5kZnrRkPGnJjMnzdHhcc4ujorqenZV1bUJNPbv217G+vIb31u2myndKgDxPKv+56njyPAotItFCgUWkE4EOCznneHT+Fn7x3EpanOMX507g68ccoV6VPpKYYAeHhyZ3clxNfRPLtlXyX/fP48pHPubhS48hKQT77IhI8Ok3VaQT/sNCHZ1baEflAf7r/vlc/6+lTBiSxdxrTuCiY4crrESgjNQkjhk1iF+fN5EPN+7h9pdWh7skEQmQAotIF87q4NxCzjme+Ggrp/7hLeZv3MNNM0p55NJjI375sMCXjhzKRccewV/e3MCLy3aGuxwRCYCGhES60N6w0K79ddzwr6W8uqqMo0YM4PbzJzMiJyPMlUp3/M/ZJSzdWsmPHl/M2AIPI/XvJxLR1MMi0oW2w0L//ngbp/7hLd5ZV8H/nF3Co5d9RmElCqUmJfKni6aRlGh876GPqG1oCndJItIJBRaRALQOC533p/e45tFFjM7N4IWrP8e3jx9Jgvb6iFpD+vfjjllHsqasip8+tYxo20hTJJ4osIgE4ITiXDypSazeVcUNZ47j8e8dx6jczHCXJUFwQnEu3z+lmKc+3sbDH24Odzki0gHNYREJQFpyIrMvO5bM1CQN/8SgK04aw8LNe7n52RVMGJLNlGH9w12SiLShHhaRAE0Ykq2wEqMSEow/fnUKuZ5U/vvhheypaQh3SSLShgKLiAjQPz2Fey6aRnlVPVfP+Zjmtnv9i0hYKbCIiPhMHJrNTTNLeXttBXe8ujbc5YiIHwUWERE/s44axvnThnLnq2t5fVVZuMsRER8FFhERP2bGLTMnMH5wFtc8uogte2rDXZKIoMAiInKYfimJ3HPRVFqc4/89vJC6xuZwlyQS9xRYRETaMXxQBr+/YApLt1Vy07Mrwl2OSNxTYBER6cAXS/L5fyeOZva8zTy+YEu4yxGJawosIiKduPaLxRw3ehA/+/cylm+vDHc5InFLgUVEpBNJiQnceeGR9E9P5vJ/LqTyQGO4SxKJSwosIiJdyMlM5U9fn8r2fQf4wWOLaNGmciJ9ToFFRCQA04YP5KdnjeeVlWXc89b6cJcjEncUWEREAnTxcSM4Z3Ihv527mvfWVYS7HJG4osAiIhIgM+PW8yYyKjeTK2d/zI7KA+EuSSRuKLCIiHRDRmoS91w0jbrGZv774YU0NLWEuySRuKDAIiLSTWPyMvnN+ZNYuHkfv3p+ZbjLEYkLCiwiIj1w9qRCLvnsSP7x3iaeWbw93OWIxDwFFhGRHvrJmeOYPnwA1z+5hLW7qsJdjkhMU2AREemh5MQE7vraVNJTEvnePz+iur4p3CWJxCwFFhGRXijITuP/LpzKxooafvzEEpzTpnIioZAU7gJERKLdZ0YP4rrTx3HrC6vY//dGjhoxkIlDs5k0JJtBmanhLk8kJiiwiIgEwXdPGEXlgUZeWr6TP7yyhtaOliH9+zFxSLY3wAzNZuKQbPqnp4S3WJEoZNHWfTl9+nS3YMGCcJchItKhqrpGlm/fz9KtlSzZVsnSrfvYtLv24P1HDEw/2AMz0RdiPGnJYaxYJHzM7CPn3PSujlMPi4hIkHnSkjl21CCOHTXo4G2VtY0s217Jkq2VLN22j8Vb9vHckh0H7x+Vm+ELMP2ZNDSbksFZZKTqv2gJDucc9U0tHGhopraxmQMN3q/ahqaD12sbmjnQ0MSBxtbL3u+1Dc0caGziJ2eMZ9jA9LC9Bv02iIj0gez0ZD47JofPjsk5eNuemgaW+npglmyt5MONe/j3Iu+eLgnm3aBu4hBvgJk0NJspw/pjZuF6CRLBlmzdx9/f2Uh5df3BsPHp4NFEd08ynpqUQHpKIukpSfRLSaS2oTk0xQdIQ0IiIhGkrKqOZdt8PTFbK1m8tZKK6noAzps6hNvPn0xigkKLeG0or+Z3L63huaU7yO6XzOjcjIMBI9331S85yfv94PXWy5++PT056VPHJPTRz5mGhEREolCeJ42Tx6Vx8rh8wNuVv2t/Pf/84BPuen0dhnHb+ZMUWuJc2f46/vjqWh6dv4XUpASuOnkM3zlhVEzPhVJgERGJYGZGQXYaPzxtLClJCfz+5TWYwW++rNASjyoPNPKXN9fz93c30tTs+PoxR3DlyUXkemJ/+bwCi4hIlLjqC0U4B394ZQ2GN7T0Vbe9hFddYzMPvr+JP72xnn21jcyYXMgPTi1m+KCMcJfWZxRYRESiyNWnFNHiHHe8uhZQaIl1zS2OJxdu5Y8vr2F7ZR0nFOdy3WljmTAkO9yl9TkFFhGRKPP9LxbjgDtfXYsZ3HqeQkuscc7x8opd3D53NWvLqpk8NJvfXjCZ40bndP3gGKXAIiIShb5/ShE4x52veSfi/vq8iQotMWLexj385sVVfPTJXkblZPDnr0/l9AkFcb+kXYFFRCQKmdnBnpb/e20dZvCrLym0RLNVO/dz24ureW1VGflZqfz6vIl8ZdpQkhJ1nmJQYBERiVpmxrVfLMY5vEueDX55bnSHFuccjc2O+qZmGppaaGhuob7R/3sz9Y0t1De3kGhGrieVnMxUBmakRO2qqS17avnDy2t4atE2PKlJ/Pj0cVx83Aj6pSSGu7SIosAiIhLFzIwfnFqMw3H36+sB45fnToiI0PLG6jKeXrSdAw3N3sDhCyH1TS3eMOK77P06dF9PJBgMyvSGF2+ISSHXk0qu73puZio5vu/905MjYnhlT00Dd722jn9+8AlmcNnnRnH5iaN1cswOKLCIiEQ5M+OHp47FOfjTG+tJMLhlZvhCy6aKGm75zwpeXVVGTmYKAzNSSE1KJCUpgdSkBDJSk0hNSiAlKdH3PYGUxARSkxNITUwgNTnx4PWUxATf4w49vvV7U4ujoqqe8up6yqvqqfB9L69uYH1ZNeVV9TQ0Hx6AkhONQRmfDjatQaf1clZaMmnJ3lpSfc+XmpRIcqL1OuzU1Dfxt3c2cu9bG6htaOKC6cO4+pQiBmf361W7sU6BRUQkBpgZPzptLA748xvrMV9o6cuehJr6Ju5+fR1/fXsjyYnGDWeO4+LjRpKSFJ45GM459tc1fTrM+F2uqPaGnRU79rO7uoGmAE62Y+Y9x07awSDj+5586HJam5Djvc97ucU5HluwlYrqek4vLeCHp41lTF5mH7wb0U+BRUQkRpgZ153m7Wm55831QN+EFucczyzezq+eX8mu/fWcN3UI158+jrystJA+b1fMjOx+yWT3S+4yFLS0OPYdaDwYZqrqmqhv8s2XaWo+NHTVeOhy3cHLrcd5L1fXNx26z+/xdY3NtDg4dtRA7v3mNKYeMaCP3onYoMAiIhJDzIwfnz4Wh+Mvb27AMG6eWRqy0LJsWyU3Pbuc+Zv2MnFINn/6+jSmDY++D+KEBGNghnf4qjjfE7LnaWpu0aqfHlJgERGJMWbG9aePAwd/eWsDZnDTjOCGlj01Dfz2pdXMnreZgekp/ObLE/nKtGERMdk3kims9JwCi4hIDDIzrj9jHC3Ocd/bGzHg50EILU3NLTwybzO/e2kN1fVNXHzcCK45pZjsfrF7lmCJDAosIiIxysy44czxOAd/fWcjZsb/nlPS49Dy/vrd3PTsclbtrOK40YP4+YzSkA6fiPhTYBERiWFmxk/PGo8D/vbORoBuh5bt+w7wy+dX8tySHQzp3497LprKaaXaKl76lgKLiEiMMzN+dpa3p+Xv727EDG48u+vQUtfYzH1vbeDuN9bhHFxzShHfPWG0dmCVsFBgERGJA2bG/5w9Hofj/nc3keALMe2FFuccL63YxS+eW8GWPQc4c2IBN5w5nqED0sNQuYiXAouISJwwM248uwTwDg8Z8NM2oWVdWRU3PbuCt9dWUJyfySOXHsNxY3LCVLHIIQosIiJxpDW0HJqICzecOZ6q+ibueGUtD7y3iX4pifzvOSVcdOxwkrUMVyKEAouISJxpXS0EcN/bG9m27wDzNu5hd00Ds44axg9PHcugzNQwVynyaQosIiJxqDW0OOd44P1PmHpEf+6/+GgmDs0Od2ki7VJgERGJU2bGz2eU8vVjhzMmN1O71EpEU2AREYljZqbN3yQqhHQ2lZmdbmarzWydmV3fzv3XmtkKM1tiZq+a2fBQ1iMiIiLRKWSBxcwSgbuBM4AS4EIzK2lz2MfAdOfcJOAJ4LZQ1SMiIiLRK5Q9LEcD65xzG5xzDcAcYKb/Ac65151ztb6rHwBDQ1iPiIiIRKlQBpYhwBa/61t9t3Xk28AL7d1hZpeZ2QIzW1BeXh7EEkVERCQahDKwtDfd3LV7oNlFwHTg9vbud87d65yb7pybnpubG8QSRUREJBqEcpXQVmCY3/WhwPa2B5nZKcBPgc875+pDWI+IiIhEqVD2sMwHisxspJmlALOAZ/wPMLMjgb8AM5xzZSGsRURERKJYyAKLc64JuAKYC6wEHnPOLTezm81shu+w24FM4HEzW2Rmz3TQnIiIiMSxkG4c55x7Hni+zW03+l0+JZTPLyIiIrFBp+EUERGRiKfAIiIiIhFPgUVEREQingKLiIiIRDwFFhEREYl4CiwiIiIS8cy5dnfLj1hmVg58EqLmc4AKtR3ydtV27LQdjTWr7b5rV23HTtuhrHm4c67L8+5EXWAJJTNb4JybrrZD267ajp22o7Fmtd137art2Gk7lDUHSkNCIiIiEvEUWERERCTiKbB82r1qu0/aVdux03Y01qy2+65dtR07bYey5oBoDouIiIhEPPWwiIiISMRTYBEREZGIF/eBxcyGmdnrZrbSzJab2dVBbDvNzOaZ2WJf2zcFq22/50g0s4/N7D9BbneTmS01s0VmtiDIbfc3syfMbJXvff9MkNod66u39Wu/mV0TpLa/7/s3XGZms80sLRjt+tq+2tfu8t7Wa2Z/N7MyM1vmd9tAM3vZzNb6vg8IYttf8dXdYmY9XvLYQdu3+35GlpjZU2bWP4ht3+Jrd5GZvWRmhcFq2+++H5qZM7OcINX8czPb5vfzfWYwazazK81ste/f87ZgtW1mj/rVvMnMFgWx7Slm9kHr/1NmdnQQ255sZu/7/h981syyetBuu58vwfid7KTtXv9OdtJ2UH4ne8w5F9dfwGBgqu+yB1gDlASpbQMyfZeTgQ+BY4Nc/7XAI8B/gtzuJiAnRO/5A8ClvsspQP8QPEcisBPvhkS9bWsIsBHo57v+GHBxkOqcACwD0oEk4BWgqBftnQBMBZb53XYbcL3v8vXAb4LY9nhgLPAGMD3IdZ8KJPku/ybIdWf5Xb4KuCdYbftuHwbMxbvJZbd/jzqo+efAD4PwM9de2yf5fvZSfdfzgvl++N3/O+DGINb9EnCG7/KZwBtBbHs+8Hnf5UuAW3rQbrufL8H4neyk7V7/TnbSdlB+J3v6Ffc9LM65Hc65hb7LVcBKvB9QwWjbOeeqfVeTfV9Bm+VsZkOBs4C/BqvNUPP9lXIC8DcA51yDc25fCJ7qC8B651ywdkVOAvqZWRLecLE9SO2OBz5wztU655qAN4Ev9bQx59xbwJ42N8/EGxLxfT83WG0751Y651b3pL0A2n7J954AfAAMDWLb+/2uZtDD38sO3m+APwDXhaDdXuug7cuBW51z9b5jyoLYNgBmZsAFwOwgtu2A1p6PbHr4e9lB22OBt3yXXwa+3IN2O/p86fXvZEdtB+N3spO2g/I72VNxH1j8mdkI4Ei8PSHBajPR1wVaBrzsnAta28Af8TV4nPEAAAiISURBVP6n2BLENls54CUz+8jMLgtiu6OAcuB+8w5l/dXMMoLYfqtZ/7+9+w+yqqzjOP7+IFJhxqBF6UiDkUCOYxsIUSgS7DjaMFtYDDE0WfqHYvirwXEYHIecqUygmumHlliWooVBSpahYytj/gCE+LEBaioJpMhUk0lJEp/+eJ6tw7a7sHefldvyfc3cuXfv3fM9Z8/d557veZ7nni81fjC2ZXsnsAB4AXgR+KvtB0rEJvWujJd0vKT+pLPEwYVit3qn7RchfRABgwrHfyNcCNxfMqCkL0naDswArisYtwnYaXtDqZgVs3J3/PdrHdrrwDDgLEmrJK2UNLpg7FZnAbtsP1Mw5pXA/Pw+LgDmFIzdAjTlx1PpZrtsc3wp2iZ74th1CLGLt8mDiYQlk/RWYClwZZuzr26x/S/bDaRMdIyk00rElTQZeNn22hLx2jHO9kjgPODzksYXituX1PV6k+0PAHtIXaLFSOpH+qC5u1C8gaQzopOBE4FjJH26RGzbW0hdqw8CvwI2APs6XegII2kuaZ8sLhnX9lzbg3PcWSVi5qRzLgUToIqbgKFAAylxXlgwdl9gIDAWuBpYkntESppOoZOIipnAVfl9vIrcc1vIhaTPvrWkYZF/1hqop44vhyt2T7XJg4mEBZB0NOlNWWx7WU+sIw97PAycWyjkOKBJ0jbgx8BESXcUio3tP+b7l4GfATVNZmvHDmBHpafpp6QEpqTzgHW2dxWK1wg8b3u37deBZcCHC8XG9q22R9oeT+qWLnkGCrBL0gkA+b6m7v7DQdIFwGRghvPAeQ+4kxq6+zswlJTYbsht8yRgnaR3dTew7V35BGg/cAvl2iSkdrksD2OvJvXadnmycEfyUOr5wE9KxcwuILVHSCcoxfaJ7a22z7E9ipRoPVtLnA6OL0XaZE8euzqK/Qa1yXYd8QlLPou4Fdhi+2uFY7+jdRa1pLeQDnxbS8S2Pcf2SbaHkIY/fm27yFm/pGMkHdv6mDTR6n++BVEL2y8B2yUNz09NAjaXiF1R+kzuBWCspP75/2USaUy3CEmD8v27SR/qpc9Cl5M+2Mn39xaO3yMknQtcAzTZ/nvh2KdUfmyiXLvcZHuQ7SG5be4gTV58qbuxWw9w2RQKtcnsHmBiXs8w0mT4kpV5G4GttncUjAlpzsrZ+fFECib7lXbZB7gWuLmGGB0dX7rdJnv42NVu7J5sk4eku7N2/99vwJmk+RobgfX59tFCsU8Hfptjt1Dj7PhDWM8ECn5LiDTPZEO+/Q6YW3h7G4An8365BxhYMHZ/4E/AgMLb/EXSQa0FuJ38bYpCsR8hJW0bgEndjHUXabjgddLB8iLgeOAh0of5Q8BxBWNPyY/3AruAFQVj/x7YXmmXtX6Tp73YS/N7uRH4OWlCYZHYbV7fRm3fEmpvm28HNuVtXg6cUHB/9APuyPtkHTCx5P4AbgMu6YH/7TOBtbntrAJGFYx9BenbMU8DN5CvDN/FuO0eX0q0yU5id7tNdhK7SJus9RaX5g8hhBBC3Tvih4RCCCGEUP8iYQkhhBBC3YuEJYQQQgh1LxKWEEIIIdS9SFhCCCGEUPciYQmhl1KqFLyw8vNsSfMKxb5N0idLxDrIeqbmirHN7bw2P1eSnV9D3AbVWO04hHB4RMISQu+1FzhfUrErlpYg6agu/PpFwKW2P9LOaxeTLsp2dQ2b0UC6rsQhUxKfmSEcJtH4Qui99gHfI9VYOUDbHhJJr+b7Cbn43RJJT0u6QdIMSaslbZI0tBKmUdIj+fcm5+WPyj0fa3KRvosrcZsl3Um6+Fnb7Zme47dI+mp+7jrSBaxubtuLImk5qcryKknT8lWll+b1rpE0Lv/eGEmPKRXafEzS8Fxr6npgmqT1efl5kmZX4rdIGpJvWyR9h3RBtcGSzpH0uKR1ku7O9VbI+2pz/rsXdPXNCiF0ru/h3oAQQo/6NrBR0o1dWOb9wPtIdY2eAxbZHiPpCuAyUoVcgCGky6IPBZolvRf4DKma9WhJbwIeldRa2XoMcJrt56srk3QiqQDkKOAvpCrhH7d9vaSJwGzbT1aXsd0k6VWnwqLkROjrtn+TSxysyH/DVmC87X2SGoEv2/5ETobOsD0rLz+vk/0xHPic7Utzb9W1QKPtPZKuAb4g6VukK4yOsO3WkhwhhHIiYQmhF7P9iqQfAZcD/zjExdY4lbxH0rNAa8KxCagOzSxxKsT3jKTngBGkulOnV3pvBgCnkCrdrm6brGSjgYdt787rXAyMJ5VtOFSNwKn6b4Hht+V6WAOAH+baQQaO7kLMVn+w/UR+PBY4lZSIQbqk/ePAK8BrwCJJvwDuq2E9IYRORMISQu/3DdJwxg8qz+0jDwnnQmf9Kq/trTzeX/l5Pwd+ZrSt62FAwGW2V1RfkDQB2NPB9qmD57uiD/Ah2wckZZK+CTTbniJpCKlienv+sz+yN1ceV7dbwIO2p7cNIGkMqTDmp4BZ5GKCIYQyYg5LCL2c7T8DS0gTWFttIw3BAHyM2noepkrqk+e1vAd4ijQUM1OpND2ShilV/O7MKuBsSW/PE3KnAyu7uC0PkJIE8nob8sMBwM78+LOV3/8bcGzl523AyLzsSODkDtbzBDAuD3+hVMF7WJ7HMsD2L0lDZg0dLB9CqFEkLCEcGRYC1W8L3UJKElYDH6Tj3o/OPEVKLO4nVeJ9DVhEqjy9TlIL8F0O0pObh5/mAM2kqrvrbN/bxW25HDgjT3jdDFySn78R+IqkR4Hqt5OaSUNI6yVNI1VvPk7SemAmqUJve9u6m5T43CVpIymBGUFKfu7Lz62knYnOIYTuiWrNIYQQQqh70cMSQgghhLoXCUsIIYQQ6l4kLCGEEEKoe5GwhBBCCKHuRcISQgghhLoXCUsIIYQQ6l4kLCGEEEKoe/8Gw56cNL9U8RgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 648x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(9,7))\n",
+    "plt.plot(nfeatures, p)\n",
+    "plt.xlabel(\"Number of features\")\n",
+    "plt.ylabel(\"UPM p-value\")\n",
+    "plt.title(\"UPM p-value vs Number of Features\")\n",
+    "plt.xticks(nfeatures)\n",
+    "plt.savefig(\"pval_vs_nfeatures_all.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I added a notebook which ranks features on importance, computes UPM coefficients and p-values for logit fits as features are removed in order of increasing significance, and makes a visual plot of this. The fits are run on the entire data set. I also created a Python file called `baseball_utils.py` to hold functions we keep reusing; so far I have added only `prepare_df(df)` but there are more we can add as needed, to clean up our notebook files. Could you approve my pull request?